### PR TITLE
simplify play viewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Full build: tangle .nw → .py, build package, run tests, compile PDF
+make all
+
+# Initialize git submodule (required first time)
+git submodule update --init
+
+# Tangle and build package only
+cd src/learnlog && make compile
+
+# Run tests (tangles test chunks from .nw files automatically)
+cd tests && make test
+# Or directly after tangling:
+poetry run pytest -v
+# Single test:
+poetry run pytest tests/unit/test_cli.py::test_find_learnlog_dir -v
+
+# Build PDF documentation
+cd doc && make
+
+# Install in editable mode
+make install
+
+# Clean build artifacts
+make clean
+```
+
+## Literate Programming (Critical)
+
+**The `.nw` files are the source of truth.** Never edit generated `.py` files directly — always edit the corresponding `.nw` file in `src/learnlog/` and tangle.
+
+- `notangle -R"[[filename.py]]" file.nw` extracts Python code
+- `noweave` extracts LaTeX documentation
+- Code chunks: `<<[[filename.py]]>>=`
+- Test chunks: `<<test [[filename.py]]>>=` (auto-discovered by `tests/Makefile`)
+- **Always activate the `literate-programming` skill before editing `.nw` files**
+- Use the `review-literate-programming` skill to review literate quality of changes
+
+### Related skills
+
+- `latex-writing` — for LaTeX conventions in `.nw` documentation sections
+- `variation-theory` — for structuring educational content in documentation
+- `try-first-tell-later` — for pedagogical exercise design
+
+## Architecture
+
+Four modules, all defined as `.nw` literate source in `src/learnlog/`:
+
+| Module | File | Purpose |
+|--------|------|---------|
+| `__init__.py` | `learnlog.nw` | Auto-initializes on import; wraps stdout/stderr/stdin for transparent I/O capture; atexit cleanup |
+| `capture.py` | `capture.nw` | `IOLog` (thread-safe shared buffer), `StreamCapture`/`InputCapture` (transparent tee wrappers); strips ANSI escapes |
+| `gitrepo.py` | `gitrepo.nw` | `LearnlogRepo` manages `.learnlog/` hidden Git repo with `--git-dir=.learnlog --work-tree=.`; crash-resilient commit strategy (commit header before run, amend with results after) |
+| `cli.py` | `cli.nw` | Typer CLI with `export` (git bundle) and `play` (curses viewer + batch mode) commands |
+
+### Key design constraints
+
+- **Transparency**: student programs must behave identically with/without learnlog
+- **Crash resilience**: `begin_run()` commits before execution, `finalize_run()` amends after
+- `.learnlog/` in the working directory is the *product's* data (student log repo), not project config
+- Git operations use `subprocess.run` (no GitPython dependency)
+- Only runtime dependency: `typer>=0.9.0`
+
+## Testing
+
+Tests are embedded in `.nw` files as `<<test [[module.py]]>>=` chunks. The `tests/Makefile` auto-discovers and tangles them to `tests/unit/test_*.py` before running pytest.
+
+Key test patterns:
+- Temporary directories with `tmp_path` fixture for Git operations
+- Subprocess-based integration tests for full import-capture-commit pipeline
+- `CliRunner` from Typer for CLI command testing (note: CliRunner doesn't connect a real TTY)
+
+## CI
+
+CircleCI with `dbosk/makefiles` Docker image. Runs `make all` which tangles, builds, tests, and compiles PDF.

--- a/src/learnlog/capture.nw
+++ b/src/learnlog/capture.nw
@@ -23,9 +23,11 @@ buffer while passing data through to the original streams unchanged.
 """
 
 import io
+import re
 import threading
 
 <<constants>>
+<<helper functions>>
 <<classes>>
 @
 
@@ -59,6 +61,66 @@ normally.
 MAX_IOLOG_BYTES = 1_000_000
 @
 
+\subsection{ANSI escape code stripping}
+\label{ansi-stripping}
+
+Starting with Python~3.13, the interpreter emits coloured tracebacks
+using ANSI escape codes (CSI sequences such as \verb|\x1b[31m| for red
+text).
+These sequences are meaningful to a terminal emulator but are
+unreadable noise when stored as plain text in a Git commit message.
+We therefore strip all CSI sequences from captured text before
+buffering it, while still passing the raw (coloured) text through to
+the student's terminal unchanged.
+
+The regex matches the standard CSI pattern: an escape character
+(\verb|\x1b|), a left bracket, optional numeric parameters separated
+by semicolons, and a single letter command.
+This covers colours, bold/underline, cursor movement, and line
+clearing---everything Python's traceback colouring produces.
+We precompile the pattern into a module-level constant because
+[[strip_ansi]] is called on every single write.
+
+<<helper functions>>=
+_ANSI_ESCAPE_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')
+
+def strip_ansi(text):
+    """Remove ANSI escape sequences from ``text``."""
+    return _ANSI_ESCAPE_RE.sub('', text)
+@
+
+We need to verify two directions: that escape codes are actually
+stripped (otherwise Python~3.13 tracebacks remain unreadable), and
+that plain text passes through unmodified (otherwise we would corrupt
+output that happens to contain bracket characters):
+
+<<test functions>>=
+def test_strip_ansi_removes_color_codes():
+    colored = "\x1b[31mError\x1b[0m: something failed"
+    assert strip_ansi(colored) == "Error: something failed"
+
+def test_strip_ansi_preserves_plain_text():
+    plain = "hello world\n"
+    assert strip_ansi(plain) == plain
+
+def test_strip_ansi_handles_multiple_codes():
+    text = "\x1b[1m\x1b[31mBold Red\x1b[0m Normal"
+    assert strip_ansi(text) == "Bold Red Normal"
+
+def test_strip_ansi_empty_string():
+    assert strip_ansi("") == ""
+
+def test_iolog_strips_ansi_from_logged_text():
+    log = IOLog()
+    log.log("stderr", "\x1b[31mTraceback\x1b[0m\n")
+    value = log.getvalue()
+    assert "\x1b[" not in value
+    assert "stderr: Traceback\n" in value
+@
+
+
+\subsection{The [[IOLog]] class}
+
 <<classes>>=
 class IOLog:
     """Thread-safe shared buffer for interleaved I/O logging.
@@ -82,6 +144,12 @@ class IOLog:
 \subsection{Logging a line}
 
 The [[log]] method is the core of [[IOLog]].
+Before splitting the text into lines, we strip any ANSI escape
+sequences (see \cref{ansi-stripping}).
+This ensures the buffered log is clean plain text, while the student's
+terminal still shows colours since [[StreamCapture.write]] passes
+the original (unstripped) text to the real stream.
+
 We split each write into individual lines so that the prefix appears on
 every line, making the log easy to scan.
 The alternative---prefixing only the first line of a multi-line
@@ -93,10 +161,12 @@ def log(self, prefix, text):
     """Log ``text`` with ``prefix`` (e.g. ``'stdout'``).
 
     Each line of ``text`` gets its own prefixed entry.
+    ANSI escape sequences are stripped before buffering.
     If the buffer is full, further writes are silently dropped.
     """
     if not text:
         return
+    text = strip_ansi(text)
     with self.lock:
         if self.truncated:
             return

--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -319,10 +319,14 @@ def test_get_commits_has_required_keys(workdir):
 
 \subsection{Commit details}
 
-For a single commit, we fetch the full message and the diff.
-The diff shows what changed compared to the parent commit.
-For the initial commit, we use [[--root]] to show all files as
-additions.
+For a single commit we use [[git show]], which produces exactly
+the output a teacher would see when inspecting the [[.learnlog/]]
+repository manually: the commit header, the full message
+(containing the captured I/O), and the unified diff (showing the
+code that changed).
+Using [[git show]] instead of separate calls for the message and
+the diff is both simpler and faster---one subprocess instead of
+three.
 
 We load details lazily---only when the user navigates to a
 particular commit---to keep the viewer responsive even for
@@ -330,31 +334,15 @@ repositories with hundreds of commits.
 
 <<commit data functions>>=
 def get_commit_detail(repo, commit_hash):
-    """Return detailed information for a single commit.
+    """Return the ``git show`` output for a single commit.
 
-    Returns a dict with ``message`` (full commit message) and
-    ``diff`` (unified diff against parent).
+    The result is a string containing the commit header,
+    message, and unified diff---the same output a teacher
+    would see by running ``git show`` in the ``.learnlog/``
+    repository.
     """
-    msg_result = repo.git(
-        "log", "-1", "--format=%B", commit_hash
-    )
-    message = msg_result.stdout.rstrip("\n")
-
-    parent_result = repo.git(
-        "rev-parse", commit_hash + "^"
-    )
-    if parent_result.returncode == 0:
-        diff_result = repo.git(
-            "diff", parent_result.stdout.strip(),
-            commit_hash
-        )
-    else:
-        diff_result = repo.git(
-            "diff", "--root", commit_hash
-        )
-    diff = diff_result.stdout
-
-    return {"message": message, "diff": diff}
+    result = repo.git("show", commit_hash)
+    return result.stdout
 @
 
 <<test functions>>=
@@ -363,8 +351,7 @@ def test_get_commit_detail_initial(workdir):
     repo = LearnlogRepo(workdir)
     commits = get_commits(repo)
     detail = get_commit_detail(repo, commits[0]["hash"])
-    assert "message" in detail
-    assert "diff" in detail
+    assert "learnlog" in detail
 
 def test_get_commit_detail_with_diff(workdir):
     from learnlog.cli import get_commits, get_commit_detail
@@ -376,7 +363,7 @@ def test_get_commit_detail_with_diff(workdir):
     repo.begin_run("hello.py", [], t2)
     commits = get_commits(repo)
     detail = get_commit_detail(repo, commits[-1]["hash"])
-    assert "hello.py" in detail["diff"]
+    assert "hello.py" in detail
 @
 
 
@@ -485,10 +472,18 @@ def run(self):
 Each iteration draws the screen and waits for a keypress.
 We redraw on every key because the state may have changed.
 
+We call [[curses.use_default_colors]] so that the viewer inherits
+the terminal's native background and foreground colours instead
+of forcing white-on-black.
+This respects light themes, transparency, and custom colour
+schemes---details that matter when learnlog runs on diverse
+student and teacher machines.
+
 <<player methods>>=
 def _main_loop(self, stdscr):
     """Main event loop inside curses."""
     import curses
+    curses.use_default_colors()
     curses.curs_set(0)
     stdscr.clear()
 
@@ -513,16 +508,16 @@ handling arbitrarily long diffs.
 
 <<player methods>>=
 def _get_detail(self, commit_hash):
-    """Fetch and cache commit detail."""
+    """Fetch and cache the ``git show`` output."""
     if commit_hash not in self._detail_cache:
         self._detail_cache[commit_hash] = \
             get_commit_detail(self.repo, commit_hash)
     return self._detail_cache[commit_hash]
 @
 
-We cache commit details because [[get_commit_detail]] shells out to
-Git twice (once for the message, once for the diff).
-Without caching, every scroll keystroke would re-run those commands,
+We cache the [[git show]] output because fetching it shells out to
+Git.
+Without caching, every scroll keystroke would re-run the command,
 making the viewer sluggish on large repositories.
 
 <<player methods>>=
@@ -565,15 +560,12 @@ except curses.error:
     pass
 @
 
-The content combines the commit message and the diff,
-separated by a blank line.
+The content is the raw [[git show]] output, which already
+combines the commit header, message, and diff.
 We split into lines for scrollable display.
 
 <<build content lines>>=
-content_text = detail["message"]
-if detail["diff"]:
-    content_text += "\n\n" + detail["diff"]
-content_lines = content_text.split("\n")
+content_lines = detail.split("\n")
 @
 
 We display lines starting from the scroll offset, filling

--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -319,14 +319,67 @@ def test_get_commits_has_required_keys(workdir):
 
 \subsection{Commit details}
 
-For a single commit we use [[git show]], which produces exactly
-the output a teacher would see when inspecting the [[.learnlog/]]
-repository manually: the commit header, the full message
-(containing the captured I/O), and the unified diff (showing the
-code that changed).
-Using [[git show]] instead of separate calls for the message and
-the diff is both simpler and faster---one subprocess instead of
-three.
+For a single commit we use [[git show]], which produces the
+commit header, the full message (containing the captured I/O),
+and the unified diff (showing the code that changed)---all in a
+single subprocess call.
+
+A teacher reviewing student work typically wants to see
+\emph{what changed} before reading the run metadata (script
+name, arguments, captured I/O).
+The default [[git show]] order is header, message, diff; we
+rearrange to header, diff, message so that code changes appear
+first.
+
+<<helper functions>>=
+def reorder_commit_detail(detail):
+    """Reorder ``git show`` output: header, diff, message.
+
+    Moves the unified diff before the commit message so that
+    code changes are visible first in the viewer.
+    """
+    lines = detail.split("\n")
+
+    <<find header boundary>>
+    <<find diff boundary>>
+
+    header = lines[:header_end + 1]
+    message = lines[header_end + 1:diff_start]
+    diff = lines[diff_start:]
+
+    return "\n".join(header + diff + [""] + message)
+@
+
+The [[git show]] output always starts with metadata lines
+(commit hash, author, date) followed by a blank line, then the
+indented commit message, then the diff.
+We locate the first blank line to separate the header from the
+message.
+
+<<find header boundary>>=
+header_end = 0
+for i, line in enumerate(lines):
+    if line == "":
+        header_end = i
+        break
+@
+
+The diff section starts at the first line matching
+[[diff --git]].
+When no diff is present---for example, the initial commit that
+only records a run without any file changes---we return the
+output unchanged.
+
+<<find diff boundary>>=
+diff_start = None
+for i, line in enumerate(lines):
+    if line.startswith("diff --git "):
+        diff_start = i
+        break
+
+if diff_start is None:
+    return detail
+@
 
 We load details lazily---only when the user navigates to a
 particular commit---to keep the viewer responsive even for
@@ -334,15 +387,14 @@ repositories with hundreds of commits.
 
 <<commit data functions>>=
 def get_commit_detail(repo, commit_hash):
-    """Return the ``git show`` output for a single commit.
+    """Return ``git show`` output for a single commit,
+    reordered so the diff appears before the message.
 
-    The result is a string containing the commit header,
-    message, and unified diff---the same output a teacher
-    would see by running ``git show`` in the ``.learnlog/``
-    repository.
+    The result places code changes first, followed by the
+    commit message with run metadata and captured I/O.
     """
     result = repo.git("show", commit_hash)
-    return result.stdout
+    return reorder_commit_detail(result.stdout)
 @
 
 <<test functions>>=
@@ -364,6 +416,27 @@ def test_get_commit_detail_with_diff(workdir):
     commits = get_commits(repo)
     detail = get_commit_detail(repo, commits[-1]["hash"])
     assert "hello.py" in detail
+
+def test_get_commit_detail_diff_before_message(workdir):
+    """Verify that the diff appears before the message."""
+    from learnlog.cli import get_commits, get_commit_detail
+    repo = LearnlogRepo(workdir)
+    t1 = datetime.datetime(2026, 1, 1, 10, 0)
+    repo.begin_run("hello.py", [], t1)
+    (workdir / "hello.py").write_text('print("v2")\n')
+    t2 = datetime.datetime(2026, 1, 1, 10, 5)
+    repo.begin_run("hello.py", [], t2)
+    commits = get_commits(repo)
+    detail = get_commit_detail(repo, commits[-1]["hash"])
+    diff_pos = detail.index("diff --git")
+    msg_lines = [
+        l for l in detail.split("\n")
+        if l.startswith("    ")
+    ]
+    assert msg_lines, "expected indented message lines"
+    first_msg_pos = detail.index(msg_lines[0])
+    assert diff_pos < first_msg_pos, \
+        "diff should appear before the commit message"
 @
 
 
@@ -560,8 +633,9 @@ except curses.error:
     pass
 @
 
-The content is the raw [[git show]] output, which already
-combines the commit header, message, and diff.
+The content is the reordered [[git show]] output, which places
+the diff before the commit message so that code changes appear
+first.
 We split into lines for scrollable display.
 
 <<build content lines>>=

--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -778,6 +778,43 @@ def test_handle_key_jump_endpoints():
 @
 
 
+\subsection{Batch playback}
+\label{sec:play-batch}
+
+The curses viewer requires a terminal, but sometimes we want to
+pipe the output through [[less]] or redirect it to a file.
+In batch mode the viewer simply prints all commits sequentially
+to standard output.
+This creates a natural reading flow: the captured output from
+one commit appears just before the diff of the next, so the
+reader sees what the program produced and what the student
+changed as a result in a single continuous stream.
+
+<<play viewer>>=
+def play_batch(repo, commits, start_index=0):
+    """Print commit details sequentially to stdout."""
+    for commit in commits[start_index:]:
+        detail = get_commit_detail(repo, commit["hash"])
+        sys.stdout.write(detail)
+        sys.stdout.write("\n")
+@
+
+Let's verify that batch playback produces the expected output
+for each commit:
+
+<<test functions>>=
+def test_play_batch_outputs_all_commits(workdir, capsys):
+    """Batch mode prints every commit's detail to stdout."""
+    from learnlog.cli import play_batch, get_commits
+    repo = LearnlogRepo(workdir)
+    commits = get_commits(repo)
+    play_batch(repo, commits)
+    captured = capsys.readouterr().out
+    for c in commits:
+        assert c["hash"][:7] in captured
+@
+
+
 \section{Typer application}
 
 We define the Typer app at module level with two commands.
@@ -865,6 +902,15 @@ directories and bundle files.
 When a bundle is used, [[resolve_source]] creates a temporary
 directory that we must clean up---hence the [[finally]] block.
 
+The [[-b]] / [[--batch]] flag selects batch mode
+(\cref{sec:play-batch}), which prints all commits to standard
+output instead of launching the curses viewer.
+When the flag is not given explicitly, we auto-detect: if
+standard output is not a terminal (for example when piped to
+[[less]]), batch mode activates automatically.
+This means [[learnlog play | less]] just works without the user
+having to remember the flag.
+
 <<typer commands>>=
 @app.command()
 def play(
@@ -881,8 +927,19 @@ def play(
     start: Annotated[
         Optional[str],
         typer.Option(
-            "--start",
+            "--start", "-s",
             help="Commit hash to start playback from.",
+        ),
+    ] = None,
+    batch: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--batch", "-b",
+            help=(
+                "Print all commits to stdout instead of "
+                "the interactive viewer.  Auto-enabled "
+                "when stdout is not a terminal."
+            ),
         ),
     ] = None,
 ):
@@ -899,15 +956,50 @@ def play(
         if start:
             <<find starting commit index>>
 
-        viewer = PlaybackViewer(repo, commits, start_index)
-        viewer.run()
+        <<choose playback mode>>
     finally:
         if tmpdir is not None:
             shutil.rmtree(tmpdir, ignore_errors=True)
 @
 
-When the user specifies a [[--start]] commit, we find the
-matching index by prefix.
+When [[batch]] is [[None]] (the user did not pass [[-b]]),
+we fall back to TTY detection via [[sys.stdout.isatty()]].
+An explicit [[--batch]] or [[--no-batch]] always wins.
+
+<<choose playback mode>>=
+use_batch = (
+    batch if batch is not None
+    else not sys.stdout.isatty()
+)
+if use_batch:
+    play_batch(repo, commits, start_index)
+else:
+    viewer = PlaybackViewer(repo, commits, start_index)
+    viewer.run()
+@
+
+Typer's [[CliRunner]] does not connect a real terminal, so
+invoking [[play]] through it exercises the batch path
+automatically.
+We verify that the command succeeds and that every commit
+appears in the output:
+
+<<test functions>>=
+def test_play_batch_via_cli(workdir):
+    """The play command uses batch mode when not a TTY."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    repo = LearnlogRepo(workdir)
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["play", str(workdir)]
+    )
+    assert result.exit_code == 0
+    assert "diff --git" in result.output
+@
+
+When the user specifies a [[--start]] / [[-s]] commit, we find
+the matching index by prefix.
 Short hashes work because we match the beginning of the
 full hash, just like Git does.
 


### PR DESCRIPTION
- **Simplify play viewer to use git show and respect terminal colors**
- **Strip ANSI escape codes from captured I/O before storing in commits**
- **Reorder play viewer to show diff before run metadata**
- **Add batch mode for play command with TTY auto-detection**
- **Add CLAUDE.md with build commands, architecture, and literate programming guidance**
