### PR TITLE
Add use cases for teacher live-coding and student study

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # learnlog
-A Python package to log students' code development and test runs
+
+A Python package that automatically logs code development and program runs.
+
+By adding `import learnlog` as the first import in a Python file, every
+program run is recorded transparently: source code changes, command-line
+arguments, standard input/output/error, and unhandled exceptions. The data is
+stored in a hidden local Git repository.
+
+## Use cases
+
+- **Studying how students code.**
+  Have students add `import learnlog` to their programs. The teacher can then
+  study students' development process — for research purposes or to help
+  students refine their debugging techniques.
+
+- **Sharing live-coding sessions.**
+  A teacher adds `import learnlog` to demonstration scripts during a lecture
+  or tutorial. After the session, run `learnlog export` to create a portable
+  bundle that students can replay step by step with `learnlog play`.

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -11,6 +11,20 @@ hidden Git repository, wraps the standard streams to capture all I/O,
 and registers cleanup handlers that finalise the log entry when the
 program exits.
 
+These logs serve two main use cases.
+First, a teacher can have students use learnlog to record their
+development process.
+The teacher can then study how students approach coding tasks---for
+research purposes or to help students refine their debugging
+techniques.
+
+Second, a teacher can use learnlog while live coding during a lecture
+or tutorial.
+After the session, the teacher runs [[learnlog export]] to
+produce a portable bundle, and the students replay it step by step
+with [[learnlog play]]---seeing the exact sequence of code
+changes, inputs, and outputs from the demonstration.
+
 The design is guided by two constraints:
 \begin{description}
 \item[Transparency] The student's program must behave identically


### PR DESCRIPTION
Document two use cases in the Overview chapter and README:
- Teachers study how students code (research/debugging refinement)
- Teachers share live-coding sessions via export/play

Co-authored-by: OpenCode <noreply@opencode.ai> (claude-opus-4.6)
