### PR TITLE
add canvas student page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Five modules, all defined as `.nw` literate source in `src/learnlog/`:
 | `_autostart.py` | `learnlog.nw` | Venv startup hook installed via `.pth`; resolves the project root, skips `learnlog init`, and activates `learnlog` early enough to capture `SyntaxError`, `python -c`, REPL, `pip`, and other venv-scoped runs |
 | `capture.py` | `capture.nw` | `IOLog` (thread-safe shared buffer), `StreamCapture`/`InputCapture` (transparent tee wrappers); strips ANSI escapes |
 | `gitrepo.py` | `gitrepo.nw` | `LearnlogRepo` manages `.learnlog/` hidden Git repo with `--git-dir=.learnlog --work-tree=.`; crash-resilient commit strategy (commit header before run, amend with results after) |
-| `cli.py` | `cli.nw` | Typer CLI with `export` (git bundle) and `play` (curses viewer + batch mode) commands |
+| `cli.py` | `cli.nw` | Typer CLI: `init` (project + venv + autostart), `list`, `set-remote`, `push`, `export` (git bundle), `play` (curses viewer + batch mode) |
 
 ### Key design constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Five modules, all defined as `.nw` literate source in `src/learnlog/`:
 | `_autostart.py` | `learnlog.nw` | Venv startup hook installed via `.pth`; resolves the project root, skips `learnlog init`, and activates `learnlog` early enough to capture `SyntaxError`, `python -c`, REPL, `pip`, and other venv-scoped runs |
 | `capture.py` | `capture.nw` | `IOLog` (thread-safe shared buffer), `StreamCapture`/`InputCapture` (transparent tee wrappers); strips ANSI escapes |
 | `gitrepo.py` | `gitrepo.nw` | `LearnlogRepo` manages `.learnlog/` hidden Git repo with `--git-dir=.learnlog --work-tree=.`; crash-resilient commit strategy (commit header before run, amend with results after) |
-| `cli.py` | `cli.nw` | Typer CLI: `init` (project + venv + autostart), `list`, `set-remote`, `push`, `export` (git bundle), `play` (curses viewer + batch mode) |
+| `cli.py` | `cli.nw` | Typer CLI: `init` (project + venv + autostart; honors active `$VIRTUAL_ENV`), `activate`/`deactivate` (emit shell code for the project `.venv/`), `list`, `set-remote`, `push`, `export` (git bundle), `play` (curses viewer + batch mode) |
 
 ### Key design constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,12 @@ make clean
 
 ## Architecture
 
-Four modules, all defined as `.nw` literate source in `src/learnlog/`:
+Five modules, all defined as `.nw` literate source in `src/learnlog/`:
 
 | Module | File | Purpose |
 |--------|------|---------|
 | `__init__.py` | `learnlog.nw` | Auto-initializes on import; wraps stdout/stderr/stdin for transparent I/O capture; atexit cleanup |
+| `_autostart.py` | `learnlog.nw` | Venv startup hook installed via `.pth`; resolves the project root, skips `learnlog init`, and activates `learnlog` early enough to capture `SyntaxError`, `python -c`, REPL, `pip`, and other venv-scoped runs |
 | `capture.py` | `capture.nw` | `IOLog` (thread-safe shared buffer), `StreamCapture`/`InputCapture` (transparent tee wrappers); strips ANSI escapes |
 | `gitrepo.py` | `gitrepo.nw` | `LearnlogRepo` manages `.learnlog/` hidden Git repo with `--git-dir=.learnlog --work-tree=.`; crash-resilient commit strategy (commit header before run, amend with results after) |
 | `cli.py` | `cli.nw` | Typer CLI with `export` (git bundle) and `play` (curses viewer + batch mode) commands |
@@ -65,7 +66,9 @@ Four modules, all defined as `.nw` literate source in `src/learnlog/`:
 - **Crash resilience**: `begin_run()` commits before execution, `finalize_run()` amends after
 - `.learnlog/` in the working directory is the *product's* data (student log repo), not project config
 - Git operations use `subprocess.run` (no GitPython dependency)
-- Only runtime dependency: `typer>=0.9.0`
+- Runtime dependencies: `typer>=0.9.0` (CLI) and `virtualenv>=20` (used by
+  `learnlog init` to create project venvs reliably on PEP 668 / split-
+  `python3-venv` systems)
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Five modules, all defined as `.nw` literate source in `src/learnlog/`:
 | `_autostart.py` | `learnlog.nw` | Venv startup hook installed via `.pth`; resolves the project root, skips `learnlog init`, and activates `learnlog` early enough to capture `SyntaxError`, `python -c`, REPL, `pip`, and other venv-scoped runs |
 | `capture.py` | `capture.nw` | `IOLog` (thread-safe shared buffer), `StreamCapture`/`InputCapture` (transparent tee wrappers); strips ANSI escapes |
 | `gitrepo.py` | `gitrepo.nw` | `LearnlogRepo` manages `.learnlog/` hidden Git repo with `--git-dir=.learnlog --work-tree=.`; crash-resilient commit strategy (commit header before run, amend with results after) |
-| `cli.py` | `cli.nw` | Typer CLI: `init` (project + venv + autostart; honors active `$VIRTUAL_ENV`), `activate`/`deactivate` (emit shell code for the project `.venv/`), `list`, `set-remote`, `push`, `export` (git bundle), `play` (curses viewer + batch mode) |
+| `cli.py` | `cli.nw` | Typer CLI with setup, synchronisation, export/import, tag, playback, and analysis commands — `init` (project + venv + autostart; honors active `$VIRTUAL_ENV`), `activate`/`deactivate` (emit shell code for the project `.venv/`), `list`, `clone`, `pull`, `set-remote`, `push`, `export` (git bundle), `play` (curses viewer + batch mode), `tag`, `git` (passthrough), and `analyse` |
 
 ### Key design constraints
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,6 +58,18 @@ files = [
 markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"},
+    {file = "distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -75,6 +87,32 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
 test = ["pytest (>=6)"]
+
+[[package]]
+name = "filelock"
+version = "3.19.1"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version == \"3.9\""
+files = [
+    {file = "filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d"},
+    {file = "filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58"},
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"},
+    {file = "filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90"},
+]
 
 [[package]]
 name = "iniconfig"
@@ -164,6 +202,37 @@ files = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.4.0"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version == \"3.9\""
+files = [
+    {file = "platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85"},
+    {file = "platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.14.1)"]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
+    {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
+]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
@@ -216,6 +285,26 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+description = "Python interpreter discovery"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a"},
+    {file = "python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb"},
+]
+
+[package.dependencies]
+filelock = ">=3.15.4"
+platformdirs = ">=4.3.6,<5"
+
+[package.extras]
+docs = ["furo (>=2025.12.19)", "sphinx (>=9.1)", "sphinx-autodoc-typehints (>=3.6.3)", "sphinxcontrib-mermaid (>=2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.5.4)", "pytest (>=8.3.5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
 
 [[package]]
 name = "rich"
@@ -350,14 +439,36 @@ version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version < \"3.11\""
 files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
 
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac"},
+    {file = "virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = [
+    {version = ">=3.16.1,<=3.19.1", markers = "python_version < \"3.10\""},
+    {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""},
+]
+platformdirs = ">=3.9.1,<5"
+python-discovery = ">=1.2.2"
+typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""}
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "7ec8cf01675b5e1abecd34b607dd773d7753b15384b795be94980eb057d5aa1e"
+content-hash = "9dcac40b473d9b508aaa7eb3292c97741f504a9513e732f33eb847773d0425f9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ exclude = [
   "src/learnlog/Makefile",
   "src/learnlog/*.nw",
   "src/learnlog/*.tex",
-  "src/learnlog/CLAUDE.md",
+  "src/learnlog/*.md",
   "src/learnlog/ltxobj",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Education"
 ]
 requires-python = ">=3.9"
-dependencies = ["typer>=0.9.0"]
+dependencies = ["typer>=0.9.0", "virtualenv>=20"]
 
 [project.scripts]
 learnlog = "learnlog.cli:app"

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,3 @@
 *.py
 *.tex
+learnlog/students.md

--- a/src/learnlog/Makefile
+++ b/src/learnlog/Makefile
@@ -1,6 +1,6 @@
 NOTANGLEFLAGS.py=
 
-MODULES+=	__init__.py learnlog.tex students.md
+MODULES+=	__init__.py _autostart.py learnlog.tex students.md
 MODULES+=	capture.py capture.tex
 MODULES+=	gitrepo.py gitrepo.tex
 MODULES+=	commits.py commits.tex
@@ -12,6 +12,9 @@ MODULES+=	cli.py cli.tex
 all: ${MODULES}
 
 __init__.py: learnlog.nw
+	${NOTANGLE.py}
+
+_autostart.py: learnlog.nw
 	${NOTANGLE.py}
 
 students.md: learnlog.nw

--- a/src/learnlog/Makefile
+++ b/src/learnlog/Makefile
@@ -1,6 +1,6 @@
 NOTANGLEFLAGS.py=
 
-MODULES+=	__init__.py learnlog.tex
+MODULES+=	__init__.py learnlog.tex students.md
 MODULES+=	capture.py capture.tex
 MODULES+=	gitrepo.py gitrepo.tex
 MODULES+=	commits.py commits.tex
@@ -13,6 +13,9 @@ all: ${MODULES}
 
 __init__.py: learnlog.nw
 	${NOTANGLE.py}
+
+students.md: learnlog.nw
+	${NOTANGLE}
 
 capture.py: capture.nw
 gitrepo.py: gitrepo.nw

--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -402,12 +402,16 @@ def test_do_export_creates_bundle(workdir):
 
 The [[init]] command (\cref{sec:init}) is what a student
 runs once per project to turn an ordinary working directory
-into a learnlog-enabled one.  Two independent things need
+into a learnlog-enabled one.  Three independent things need
 to happen for learnlog to record reliably, and [[init]]
-handles both: the [[.learnlog/]] repository must exist at
-the project \emph{root}, and a Python environment with
+handles all of them: the [[.learnlog/]] repository must
+exist at the project \emph{root}, a Python environment with
 [[learnlog]] installed must be available to run student
-code.
+code, and that environment must be wired up so that
+[[learnlog]] activates \emph{before} the student's script
+is compiled---otherwise a [[SyntaxError]] in [[main.py]]
+passes through silently because the explicit
+[[import learnlog]] line is never reached.
 
 The repository placement matters because [[learnlog]]
 initialises itself lazily on first import: if no
@@ -420,22 +424,41 @@ subdirectory---tangled into [[src/]] or [[lab1/]] rather
 than the project root.  Creating the repository explicitly
 up front is the simplest way to eliminate that race.
 
-The Python-environment setup exists because modern Linux
-distributions no longer let [[pip install]] touch the
-system Python.  Debian and Ubuntu mark their system
-interpreter as \enquote{externally managed} (PEP 668),
-which rejects [[pip install --user]] unless overridden
-with [[--break-system-packages]].  On such systems
-[[init]] creates [[.venv/]] and installs [[learnlog]]
-inside it; on older or unmanaged systems, the [[--user]]
-install still works without surprises and we skip the
-extra directory.
+The Python-environment setup always creates a project-local
+venv using the PyPI [[virtualenv]] package rather than the
+stdlib [[venv]] module.  The two packages are nearly
+interchangeable from the caller's perspective, but
+[[virtualenv]] bundles its own [[pip]] wheels---so it works
+even on Debian/Ubuntu systems where [[python3-venv]] is a
+separate APT package that has not been installed, and on
+PEP 668-marked Pythons where [[pip install]] against the
+system interpreter is rejected outright.  We have
+[[virtualenv]] as a runtime dependency anyway, so having a
+single code path is cheaper than maintaining a second one
+that tries stdlib [[venv]] first.  The older [[pip install
+--user]] fallback is gone: it required probing PEP 668
+state on the target interpreter, produced a different
+layout for logging (no venv means no [[.pth]] anchor), and
+broke down on the systems we most cared about supporting.
+
+The autostart wiring is a single [[.pth]] file and a small
+text marker placed inside the venv's [[site-packages]].
+[[site.py]] processes [[.pth]] files at interpreter startup,
+before the main script is compiled, so the [[sys.excepthook]]
+that [[learnlog.initialize()]] installs is in place in time
+to see top-level [[SyntaxError]]s.  The marker file records
+the project root so that scripts run from outside the
+project (for example [[python /tmp/scratch.py]] inside an
+activated venv) still commit to the right
+[[.learnlog/]].  Both files are written by
+[[write_autostart_files]]
+(\cref{sec:setup-autostart-hook}).
 
 The helpers that support [[init]] are split across the
 following subsections by concern: choosing a language,
-finding the interpreter, probing the interpreter, locating
-[[pip]] once a venv exists, and finally the pipeline that
-wires them together.
+finding the interpreter, locating [[pip]] and [[python]]
+once a venv exists, writing the autostart hook, and
+finally the pipeline that wires them together.
 
 
 \subsection{Selecting a language}
@@ -558,115 +581,57 @@ def test_resolve_target_python_errors_when_missing(monkeypatch):
 @
 
 
-\subsection{Detecting PEP 668}
-\label{sec:setup-pep668}
-
-PEP 668 specifies that a packager who does not want
-[[pip install]] to touch a Python installation marks it by
-dropping an empty [[EXTERNALLY-MANAGED]] file into the
-interpreter's standard-library directory.  The path is
-reported by [[sysconfig.get_path('stdlib')]]
-\emph{for that interpreter}, which is the complication:
-[[sysconfig]] in our own process reports \emph{our} paths,
-not the target's.
-
-The probe below shells out to the target Python and asks
-it to compute and check the path.  This works regardless
-of whether the target is a system Python, a pyenv shim, or
-some custom build, because the interpreter itself is
-authoritative about where its own stdlib lives.  The probe
-prints [[1]] or [[0]] rather than using an exit code so
-that errors in the probe itself (a broken interpreter)
-surface as [[CalledProcessError]] rather than silently
-looking like \enquote{not managed}.
-
-<<helper functions>>=
-def is_externally_managed(python_exe):
-    """Return True if the target Python is PEP 668-marked.
-
-    Shells out to ``python_exe`` to ask it about its own
-    standard-library path and check for the
-    ``EXTERNALLY-MANAGED`` marker file.  Raises
-    ``CalledProcessError`` if the probe itself fails.
-    """
-    probe = (
-        "import sysconfig, os, sys; "
-        "p = os.path.join("
-        "sysconfig.get_path('stdlib'), "
-        "'EXTERNALLY-MANAGED'); "
-        "sys.stdout.write('1' if os.path.exists(p) "
-        "else '0')"
-    )
-    result = subprocess.run(
-        [str(python_exe), "-c", probe],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=10,
-    )
-    return result.stdout.strip() == "1"
-@
-
-The easiest way to verify the probe is to run it against
-the currently-executing interpreter and compare to a
-direct filesystem check---both answers must agree whatever
-the host distro happens to be.
-
-<<test functions>>=
-def test_is_externally_managed_matches_filesystem():
-    """Probe result agrees with a direct file check."""
-    import sysconfig
-    from learnlog.cli import is_externally_managed
-    marker = (
-        pathlib.Path(sysconfig.get_path("stdlib"))
-        / "EXTERNALLY-MANAGED"
-    )
-    assert is_externally_managed(sys.executable) is marker.exists()
-@
-
-
-\subsection{Finding pip inside a venv}
+\subsection{Finding binaries inside a venv}
 \label{sec:setup-pip-in-venv}
 
-[[venv]] lays out its scripts differently on POSIX and
-Windows: [[bin/pip]] on the former, [[Scripts/pip.exe]] on
-the latter.  Rather than branching on [[os.name]] in every
-caller, a single helper picks the layout that actually
-exists.  Returning the path (not the string) keeps
-[[pathlib]] semantics in the callers.
+A venv lays out its scripts differently on POSIX and
+Windows: [[bin/<name>]] on the former,
+[[Scripts/<name>.exe]] on the latter.  Rather than branching
+on [[os.name]] in every caller, a single helper parameterised
+on the binary name picks the layout that actually exists.
+Returning the path (not the string) keeps [[pathlib]]
+semantics in the callers.
+
+Callers reach for this helper immediately after venv
+creation, so an absent binary means the venv itself is
+incomplete---a condition worth turning into [[SystemExit]]
+with a pointer to the directory rather than a cryptic
+[[FileNotFoundError]] from the next subprocess call.
 
 <<helper functions>>=
-def pip_in_venv(venv_dir):
-    """Return the path to ``pip`` inside a virtual environment.
+def find_in_venv(venv_dir, name):
+    """Return the path to ``name`` inside a virtual environment.
 
-    Handles POSIX (``bin/pip``) and Windows
-    (``Scripts/pip.exe``) layouts.  Raises ``SystemExit``
-    if neither is present---which means the venv is
-    broken or incomplete.
+    ``name`` is the bare binary name (``pip``, ``python``,
+    ``pytest``, ...).  Handles POSIX (``bin/<name>``) and
+    Windows (``Scripts/<name>.exe``) layouts.  Raises
+    ``SystemExit`` if neither is present---which means the
+    venv is broken or incomplete.
     """
-    for rel in ("bin/pip", "Scripts/pip.exe"):
+    for rel in (f"bin/{name}", f"Scripts/{name}.exe"):
         candidate = venv_dir / rel
         if candidate.exists():
             return candidate
     raise SystemExit(
-        f"No pip found inside venv at {venv_dir}"
+        f"No {name} found inside venv at {venv_dir}"
     )
 @
 
 <<test functions>>=
-def test_pip_in_venv_finds_posix_layout(tmp_path):
-    """The POSIX layout bin/pip is returned when present."""
-    from learnlog.cli import pip_in_venv
+@pytest.mark.parametrize("name", ["pip", "python"])
+def test_find_in_venv_finds_posix_layout(tmp_path, name):
+    """The POSIX layout ``bin/<name>`` is returned when present."""
+    from learnlog.cli import find_in_venv
     (tmp_path / "bin").mkdir()
-    pip = tmp_path / "bin" / "pip"
-    pip.write_text("")
-    assert pip_in_venv(tmp_path) == pip
+    binary = tmp_path / "bin" / name
+    binary.write_text("")
+    assert find_in_venv(tmp_path, name) == binary
 
-def test_pip_in_venv_errors_when_absent(tmp_path):
-    """A venv directory with no pip raises SystemExit."""
-    from learnlog.cli import pip_in_venv
+def test_find_in_venv_errors_when_absent(tmp_path):
+    """A venv directory with no match raises SystemExit."""
+    from learnlog.cli import find_in_venv
     with pytest.raises(SystemExit, match="No pip found"):
-        pip_in_venv(tmp_path)
+        find_in_venv(tmp_path, "pip")
 @
 
 
@@ -686,7 +651,7 @@ whereas Windows venvs place the scripts in [[Scripts\]] and
 have no [[source]] builtin (the student types the path to the
 activator directly, and both [[cmd.exe]] and PowerShell pick
 up the right extension via [[PATHEXT]]).  This is the same
-POSIX/Windows layout split that [[pip_in_venv]] already
+POSIX/Windows layout split that [[find_in_venv]] already
 branches on in \cref{sec:setup-pip-in-venv}, so factoring it
 into its own helper keeps the two concerns in sync---if
 Windows ever drops [[Scripts\]], both helpers fail together
@@ -741,17 +706,200 @@ def test_venv_activation_hint_windows(monkeypatch, tmp_path):
 @
 
 
+\subsection{Writing the autostart hook}
+\label{sec:setup-autostart-hook}
+
+After the venv exists, we wire it for autostart.  Two
+files are placed inside the venv's [[site-packages]]:
+\begin{description}
+\item[[[learnlog-autostart.pth]]] contains the single line
+    [[import learnlog._autostart; learnlog._autostart.autostart()]].
+    Python's [[site.py]]
+    processes [[.pth]] files at interpreter startup and
+    executes any line that begins with [[import]]
+    verbatim---\emph{before} the main script is compiled,
+    which is what lets us catch a top-level
+    [[SyntaxError]].  A [[.pth]] file is preferred over
+    [[sitecustomize.py]] because the venv may already have
+    a [[sitecustomize.py]] from some other tool (there can
+    be only one), whereas multiple [[.pth]] files coexist
+    without conflict.  [[coverage.py]] uses this same
+    mechanism ([[coverage.pth]]) for subprocess auto-start.
+\item[[[learnlog_project_root.txt]]] records the absolute
+    path of the project root.  Without it, a script run
+    from outside the project (say, [[python
+    /tmp/scratch.py]] inside an activated venv) would have
+    no way to find the matching [[.learnlog/]] by walking
+    up from its own directory.  [[_autostart]] reads this
+    file and exports it as [[LEARNLOG_PROJECT_ROOT]], which
+    [[initialize()]] consults before falling back to the
+    cwd search (\cref{learnlog}).
+\end{description}
+
+To find [[site-packages]] on both POSIX and Windows
+without branching on the host, we ask the venv's own
+interpreter via [[sysconfig.get_paths()['purelib']]].  The
+interpreter is authoritative about its own layout, so the
+same query works against stdlib [[venv]], [[virtualenv]],
+[[uv]], [[poetry]]-managed venvs, and so on.
+
+<<helper functions>>=
+def venv_purelib(venv_dir):
+    """Return the ``site-packages`` path inside ``venv_dir``.
+
+    Asks the venv's own interpreter via ``sysconfig``.
+    This gives the right answer on both POSIX
+    (``lib/pythonX.Y/site-packages``) and Windows
+    (``Lib\\site-packages``) without the caller having to
+    branch on ``os.name``.
+    """
+    probe = (
+        "import sysconfig, sys; "
+        "sys.stdout.write("
+        "sysconfig.get_paths()['purelib'])"
+    )
+    result = subprocess.run(
+        [str(find_in_venv(venv_dir, "python")), "-c", probe],
+        capture_output=True, text=True,
+        check=True, timeout=10,
+    )
+    return pathlib.Path(result.stdout.strip())
+@
+
+With [[purelib]] known, [[write_autostart_files]]
+installs both files.  The writes are idempotent---if the
+file exists with the same bytes, we leave it alone---so
+re-running [[init]] after a manual tweak does not clobber
+it, and more importantly does not stamp a new mtime that
+confuses build systems watching the venv.
+
+The whole body runs inside a [[try/except OSError]]: an
+autostart hook that fails to install is a missed feature,
+not a broken install.  The student can still use
+[[learnlog]] via the traditional explicit [[import
+learnlog]] line, so [[init]] continues and just prints a
+warning.
+
+<<helper functions>>=
+def write_autostart_files(venv_dir, project_root):
+    """Install the autostart hook into ``venv_dir``.
+
+    Writes two files into the venv's ``site-packages``:
+
+    * ``learnlog-autostart.pth`` --- a one-line
+      ``import learnlog._autostart;``
+      ``learnlog._autostart.autostart()``, processed by
+      ``site.py`` at interpreter startup before the main
+      script is compiled.
+    * ``learnlog_project_root.txt`` --- the absolute
+      path of ``project_root``, read by
+      ``learnlog._autostart`` to anchor logging to the
+      right ``.learnlog/`` even when a script is run
+      from outside the project.
+
+    Writes are idempotent (identical content is left
+    alone).  Filesystem errors are reported as warnings
+    but do not abort ``init``.
+    """
+    files = [
+        (
+            "learnlog-autostart.pth",
+            "import learnlog._autostart; "
+            "learnlog._autostart.autostart()\n",
+        ),
+        (
+            "learnlog_project_root.txt",
+            str(pathlib.Path(project_root).resolve())
+            + "\n",
+        ),
+    ]
+    try:
+        purelib = venv_purelib(venv_dir)
+        for name, content in files:
+            path = purelib / name
+            if path.exists() and path.read_text() == content:
+                continue
+            path.write_text(content)
+    except OSError as exc:
+        typer.echo(
+            f"Warning: could not install autostart hook "
+            f"into {venv_dir}: {exc}",
+            err=True,
+        )
+@
+
+To verify, we monkeypatch [[venv_purelib]] to return a
+scratch directory under [[tmp_path]] so the test does not
+depend on a real venv, and then check: both files exist
+with the expected content; a second call with the same
+arguments is a no-op (file mtimes unchanged); and an
+[[OSError]] from [[venv_purelib]] surfaces as a stderr
+warning rather than a crash.
+
+<<test functions>>=
+def test_write_autostart_files_creates_both_files(
+    tmp_path, monkeypatch,
+):
+    """The .pth and marker are written into purelib."""
+    from learnlog import cli
+    purelib = tmp_path / "site-packages"
+    purelib.mkdir()
+    monkeypatch.setattr(
+        cli, "venv_purelib", lambda d: purelib,
+    )
+    cli.write_autostart_files(tmp_path / ".venv", tmp_path)
+    pth = purelib / "learnlog-autostart.pth"
+    marker = purelib / "learnlog_project_root.txt"
+    assert pth.read_text() == (
+        "import learnlog._autostart; "
+        "learnlog._autostart.autostart()\n"
+    )
+    assert marker.read_text() == str(tmp_path.resolve()) + "\n"
+
+def test_write_autostart_files_is_idempotent(
+    tmp_path, monkeypatch,
+):
+    """Identical content is not rewritten."""
+    from learnlog import cli
+    purelib = tmp_path / "site-packages"
+    purelib.mkdir()
+    monkeypatch.setattr(
+        cli, "venv_purelib", lambda d: purelib,
+    )
+    cli.write_autostart_files(tmp_path / ".venv", tmp_path)
+    pth = purelib / "learnlog-autostart.pth"
+    mtime_before = pth.stat().st_mtime_ns
+    cli.write_autostart_files(tmp_path / ".venv", tmp_path)
+    assert pth.stat().st_mtime_ns == mtime_before
+
+def test_write_autostart_files_warns_on_oserror(
+    tmp_path, monkeypatch, capsys,
+):
+    """A filesystem failure becomes a warning, not an abort."""
+    from learnlog import cli
+
+    def boom(venv_dir):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cli, "venv_purelib", boom)
+    cli.write_autostart_files(tmp_path / ".venv", tmp_path)
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+    assert "disk full" in captured.err
+@
+
+
 \subsection{The Python setup pipeline}
 \label{sec:setup-pipeline}
 
 [[init_python]] chains the helpers together.  There are
-four legitimate end states: install into an
+three legitimate end states: install into an
 already-activated venv (the VS Code scenario, discussed
 next), install into a pre-existing [[workdir/.venv/]]
-(idempotent re-run of [[init]]), create a new
-[[workdir/.venv/]] and install there (fresh PEP 668
-system), or install with [[--user]] (unmanaged system, no
-venv).
+(idempotent re-run of [[init]]), or create a fresh
+[[workdir/.venv/]] using [[virtualenv]] and install
+there.  In every case, the final step is
+[[write_autostart_files]].
 
 \paragraph{Honouring an active venv.}
 A very common way students meet [[init]] is through VS
@@ -778,6 +926,20 @@ manually-created venvs are also respected.  [[pip
 install]] itself is a no-op when the package is already
 up to date, so re-running the full pipeline is cheap.
 
+\paragraph{Why the \texttt{virtualenv} Python API.}
+We invoke [[virtualenv.cli_run(["--python", target, dest])]]
+rather than [[subprocess.run([sys.executable, "-m",
+"virtualenv", ...])]].  The subprocess form would pin the
+new venv's plumbing to the interpreter that ran the CLI
+command, which under [[pipx]] is pipx's private Python
+inside [[~/.local/share/pipx/venvs/learnlog/]]---the exact
+trap discussed in \cref{sec:setup-target-python}.  The
+library form sidesteps [[sys.executable]] entirely and
+lets [[--python]] dictate the target.  Importing
+[[virtualenv]] lazily (only on this branch, inside the
+function) also keeps [[learnlog]]'s other CLI commands
+snappy, since nothing else needs it at import time.
+
 <<helper functions>>=
 def init_python(workdir, python=None):
     """Set up a Python environment for learnlog in ``workdir``.
@@ -787,12 +949,13 @@ def init_python(workdir, python=None):
     1. An active venv from ``$VIRTUAL_ENV`` (unless
        ``python`` was given explicitly).
     2. A pre-existing ``workdir/.venv/``.
-    3. A new ``workdir/.venv/`` created off the target
-       Python---but only on PEP 668-marked systems.
-    4. A ``pip install --user`` against the target Python.
+    3. A fresh ``workdir/.venv/`` created with
+       ``virtualenv`` off the target Python.
+
+    After install, the venv is wired for autostart via
+    :func:`write_autostart_files`.
     """
     active_venv = os.environ.get("VIRTUAL_ENV")
-    venv_dir = None
     created_venv = False
 
     if python is None and active_venv:
@@ -800,27 +963,18 @@ def init_python(workdir, python=None):
     elif (workdir / ".venv").exists():
         venv_dir = workdir / ".venv"
     else:
+        from virtualenv import cli_run
         target = resolve_target_python(python)
-        if is_externally_managed(target):
-            venv_dir = workdir / ".venv"
-            subprocess.run(
-                [str(target), "-m", "venv", str(venv_dir)],
-                check=True,
-            )
-            created_venv = True
+        venv_dir = workdir / ".venv"
+        cli_run(["--python", str(target), str(venv_dir)])
+        created_venv = True
 
-    if venv_dir is not None:
-        installer = [
-            str(pip_in_venv(venv_dir)),
-            "install", "learnlog",
-        ]
-    else:
-        installer = [
-            str(target),
-            "-m", "pip", "install", "--user", "learnlog",
-        ]
+    subprocess.run(
+        [str(find_in_venv(venv_dir, "pip")), "install", "learnlog"],
+        check=True,
+    )
 
-    subprocess.run(installer, check=True)
+    write_autostart_files(venv_dir, workdir)
 
     if created_venv:
         typer.echo(venv_activation_hint(venv_dir))
@@ -830,151 +984,138 @@ The branch choices are worth verifying, and so is the
 invariant that no subprocess call ever uses
 [[sys.executable]]---that would mean the pipx trap from
 \cref{sec:setup-target-python} had reopened.  The tests
-stub out [[resolve_target_python]] and
-[[is_externally_managed]] so the pipeline is driven by
-explicit test inputs rather than host state, stub
-[[subprocess.run]] so no venv is actually created and no
-network traffic happens, and always [[delenv
-VIRTUAL\_ENV]] before each scenario so that the test
-runner's own venv (pytest typically runs inside one) does
-not accidentally select the \enquote{active venv} branch.
+stub out [[resolve_target_python]] so the pipeline is
+driven by explicit test inputs, stub [[virtualenv.cli_run]]
+so no real venv is created, stub [[subprocess.run]] so no
+network traffic happens, stub [[write_autostart_files]] so
+the autostart concern is tested separately, and always
+[[delenv VIRTUAL\_ENV]] before each scenario so that the
+test runner's own venv (pytest typically runs inside one)
+does not accidentally select the \enquote{active venv}
+branch.
 
 <<test functions>>=
-def test_init_python_creates_venv_when_managed(
+def test_init_python_creates_venv(
     tmp_path, monkeypatch,
 ):
-    """On PEP 668-marked Pythons, a venv is created and used."""
-    from learnlog.cli import init_python
+    """A fresh venv is created via virtualenv and used."""
+    from learnlog import cli
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    calls = []
+    pip_calls = []
+    cli_run_calls = []
 
-    def fake_run(cmd, *args, **kwargs):
-        calls.append(list(cmd))
-        if cmd[1:3] == ["-m", "venv"]:
-            venv_path = pathlib.Path(cmd[3])
-            (venv_path / "bin").mkdir(parents=True)
-            (venv_path / "bin" / "pip").write_text("")
+    def fake_pip(cmd, *args, **kwargs):
+        pip_calls.append(list(cmd))
 
         class Result:
             returncode = 0
 
         return Result()
 
+    def fake_cli_run(argv):
+        cli_run_calls.append(list(argv))
+        venv_path = pathlib.Path(argv[-1])
+        (venv_path / "bin").mkdir(parents=True)
+        (venv_path / "bin" / "pip").write_text("")
+
     monkeypatch.setattr(
-        "learnlog.cli.resolve_target_python",
+        cli, "resolve_target_python",
         lambda p: pathlib.Path("/opt/python3"),
     )
     monkeypatch.setattr(
-        "learnlog.cli.is_externally_managed",
-        lambda p: True,
+        cli, "write_autostart_files",
+        lambda venv_dir, workdir: None,
     )
-    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "virtualenv.cli_run", fake_cli_run,
+    )
+    monkeypatch.setattr("subprocess.run", fake_pip)
 
-    init_python(tmp_path)
+    cli.init_python(tmp_path)
 
-    assert calls[0] == [
-        "/opt/python3", "-m", "venv",
+    assert cli_run_calls == [[
+        "--python", "/opt/python3",
         str(tmp_path / ".venv"),
-    ]
-    assert calls[1][1:] == ["install", "learnlog"]
-    assert calls[1][0].endswith("/pip")
-    assert sys.executable not in {c[0] for c in calls}
-
-def test_init_python_uses_user_install_when_unmanaged(
-    tmp_path, monkeypatch,
-):
-    """Unmanaged Pythons get --user installs, no venv."""
-    from learnlog.cli import init_python
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    calls = []
-
-    def fake_run(cmd, *args, **kwargs):
-        calls.append(list(cmd))
-
-        class Result:
-            returncode = 0
-
-        return Result()
-
-    monkeypatch.setattr(
-        "learnlog.cli.resolve_target_python",
-        lambda p: pathlib.Path("/opt/python3"),
-    )
-    monkeypatch.setattr(
-        "learnlog.cli.is_externally_managed",
-        lambda p: False,
-    )
-    monkeypatch.setattr("subprocess.run", fake_run)
-
-    init_python(tmp_path)
-
-    assert calls == [[
-        "/opt/python3", "-m", "pip",
-        "install", "--user", "learnlog",
     ]]
-    assert not (tmp_path / ".venv").exists()
-    assert sys.executable not in {c[0] for c in calls}
+    assert pip_calls[0][1:] == ["install", "learnlog"]
+    assert pip_calls[0][0].endswith("/pip")
+    assert sys.executable not in {c[0] for c in pip_calls}
 
 def test_init_python_idempotent_with_existing_venv(
     tmp_path, monkeypatch,
 ):
     """An existing .venv/ is reused instead of recreated."""
-    from learnlog.cli import init_python
+    from learnlog import cli
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)
     venv = tmp_path / ".venv"
     (venv / "bin").mkdir(parents=True)
     (venv / "bin" / "pip").write_text("")
-    calls = []
+    pip_calls = []
+    cli_run_calls = []
 
-    def fake_run(cmd, *args, **kwargs):
-        calls.append(list(cmd))
+    def fake_pip(cmd, *args, **kwargs):
+        pip_calls.append(list(cmd))
 
         class Result:
             returncode = 0
 
         return Result()
 
+    def fake_cli_run(argv):
+        cli_run_calls.append(list(argv))
+
     monkeypatch.setattr(
-        "learnlog.cli.resolve_target_python",
+        cli, "resolve_target_python",
         lambda p: pathlib.Path("/opt/python3"),
     )
     monkeypatch.setattr(
-        "learnlog.cli.is_externally_managed",
-        lambda p: True,
+        cli, "write_autostart_files",
+        lambda venv_dir, workdir: None,
     )
-    monkeypatch.setattr("subprocess.run", fake_run)
-
-    init_python(tmp_path)
-
-    assert not any(
-        c[1:3] == ["-m", "venv"] for c in calls
+    monkeypatch.setattr(
+        "virtualenv.cli_run", fake_cli_run,
     )
-    assert calls[0][1:] == ["install", "learnlog"]
+    monkeypatch.setattr("subprocess.run", fake_pip)
+
+    cli.init_python(tmp_path)
+
+    assert cli_run_calls == []
+    assert pip_calls[0][1:] == ["install", "learnlog"]
 
 def test_init_python_honours_active_venv(
     tmp_path, monkeypatch,
 ):
     """VIRTUAL_ENV selects the install target, no new venv."""
-    from learnlog.cli import init_python
+    from learnlog import cli
     active = tmp_path / "active-venv"
     (active / "bin").mkdir(parents=True)
     (active / "bin" / "pip").write_text("")
     monkeypatch.setenv("VIRTUAL_ENV", str(active))
-    calls = []
+    pip_calls = []
+    cli_run_calls = []
 
-    def fake_run(cmd, *args, **kwargs):
-        calls.append(list(cmd))
+    def fake_pip(cmd, *args, **kwargs):
+        pip_calls.append(list(cmd))
 
         class Result:
             returncode = 0
 
         return Result()
 
-    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        cli, "write_autostart_files",
+        lambda venv_dir, workdir: None,
+    )
+    monkeypatch.setattr(
+        "virtualenv.cli_run",
+        lambda argv: cli_run_calls.append(list(argv)),
+    )
+    monkeypatch.setattr("subprocess.run", fake_pip)
 
-    init_python(tmp_path)
+    cli.init_python(tmp_path)
 
-    assert calls == [[
+    assert cli_run_calls == []
+    assert pip_calls == [[
         str(active / "bin" / "pip"),
         "install", "learnlog",
     ]]
@@ -984,44 +1125,90 @@ def test_init_python_explicit_python_overrides_active_venv(
     tmp_path, monkeypatch,
 ):
     """An explicit --python is respected even if a venv is active."""
-    from learnlog.cli import init_python
+    from learnlog import cli
     active = tmp_path / "active-venv"
     (active / "bin").mkdir(parents=True)
     (active / "bin" / "pip").write_text("")
     monkeypatch.setenv("VIRTUAL_ENV", str(active))
-    calls = []
+    pip_calls = []
+    cli_run_calls = []
 
-    def fake_run(cmd, *args, **kwargs):
-        calls.append(list(cmd))
-        if cmd[1:3] == ["-m", "venv"]:
-            venv_path = pathlib.Path(cmd[3])
-            (venv_path / "bin").mkdir(parents=True)
-            (venv_path / "bin" / "pip").write_text("")
+    def fake_pip(cmd, *args, **kwargs):
+        pip_calls.append(list(cmd))
 
         class Result:
             returncode = 0
 
         return Result()
 
+    def fake_cli_run(argv):
+        cli_run_calls.append(list(argv))
+        venv_path = pathlib.Path(argv[-1])
+        (venv_path / "bin").mkdir(parents=True)
+        (venv_path / "bin" / "pip").write_text("")
+
     monkeypatch.setattr(
-        "learnlog.cli.resolve_target_python",
+        cli, "resolve_target_python",
         lambda p: pathlib.Path("/opt/python3.12"),
     )
     monkeypatch.setattr(
-        "learnlog.cli.is_externally_managed",
-        lambda p: True,
+        cli, "write_autostart_files",
+        lambda venv_dir, workdir: None,
     )
-    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "virtualenv.cli_run", fake_cli_run,
+    )
+    monkeypatch.setattr("subprocess.run", fake_pip)
 
-    init_python(tmp_path, python="/opt/python3.12")
+    cli.init_python(tmp_path, python="/opt/python3.12")
 
-    assert calls[0] == [
-        "/opt/python3.12", "-m", "venv",
+    assert cli_run_calls == [[
+        "--python", "/opt/python3.12",
         str(tmp_path / ".venv"),
-    ]
+    ]]
     assert str(active / "bin" / "pip") not in {
-        c[0] for c in calls
+        c[0] for c in pip_calls
     }
+
+def test_init_python_invokes_write_autostart_files(
+    tmp_path, monkeypatch,
+):
+    """After install, the autostart hook is wired into the venv."""
+    from learnlog import cli
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    autostart_calls = []
+
+    def fake_pip(cmd, *args, **kwargs):
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    def fake_cli_run(argv):
+        venv_path = pathlib.Path(argv[-1])
+        (venv_path / "bin").mkdir(parents=True)
+        (venv_path / "bin" / "pip").write_text("")
+
+    monkeypatch.setattr(
+        cli, "resolve_target_python",
+        lambda p: pathlib.Path("/opt/python3"),
+    )
+    monkeypatch.setattr(
+        cli, "write_autostart_files",
+        lambda venv_dir, workdir: autostart_calls.append(
+            (venv_dir, workdir)
+        ),
+    )
+    monkeypatch.setattr(
+        "virtualenv.cli_run", fake_cli_run,
+    )
+    monkeypatch.setattr("subprocess.run", fake_pip)
+
+    cli.init_python(tmp_path)
+
+    assert autostart_calls == [
+        (tmp_path / ".venv", tmp_path),
+    ]
 @
 
 

--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -364,11 +364,25 @@ This is the natural serialisation format for a Git repository---it
 handles pack files correctly and can be validated from any directory
 with [[git bundle list-heads]].
 
-The default output filename is [[learnlog.bundle]], placed in the
+The default output filename is [[learnlog.learnlog]], placed in the
 current directory.
+The [[.learnlog]] extension is the product's bundle extension: the
+file on disk is a Git bundle, but naming it [[.learnlog]] makes it
+obvious to students which tool produced it and which tool will
+consume it (via [[learnlog play -f <file>]]).
+
+The bundle always contains every commit on every branch ([[--all]]).
+We deliberately do not offer a rev-range option (\eg
+[[--since <tag>]]) even though [[git bundle create]] supports one:
+a partial bundle declares prerequisite commits that the receiver
+must already have, and [[learnlog play -f]] unpacks via
+[[git clone]] which cannot satisfy prerequisites.
+The teacher's incremental workflow is therefore \enquote{export
+the whole log every time and let the student pick a lecture with
+[[learnlog list]]}, not \enquote{export just the new commits}.
 
 <<constants>>=
-DEFAULT_BUNDLE_NAME = "learnlog.bundle"
+DEFAULT_BUNDLE_NAME = "learnlog.learnlog"
 @
 
 <<export functions>>=
@@ -391,7 +405,7 @@ def do_export(repo, output):
 def test_do_export_creates_bundle(workdir):
     from learnlog.cli import do_export
     repo = LearnlogRepo(workdir)
-    bundle = workdir / "test.bundle"
+    bundle = workdir / "test.learnlog"
     do_export(repo, bundle)
     assert bundle.exists()
     verify = subprocess.run(
@@ -1827,9 +1841,9 @@ def list_commits(
         typer.Option(
             "--from", "-f",
             help=(
-                "Source: directory with .learnlog/ "
-                "a ProgSnap2 zip, or a .bundle file. "
-                "Defaults to current directory."
+                "Source: directory with .learnlog/, "
+                "a ProgSnap2 zip, or a .learnlog bundle "
+                "file. Defaults to current directory."
             ),
         ),
     ] = None,
@@ -2181,7 +2195,7 @@ export does not need bundle support---we are \emph{creating}
 bundles, not reading them.
 
 When [[--progsnap2]] is set, the default output changes from
-[[learnlog.bundle]] to [[learnlog.progsnap2]].
+[[learnlog.learnlog]] to [[learnlog.progsnap2]].
 We detect this by checking whether the user explicitly passed
 [[-o]]---if the output still equals the bundle default, we
 substitute the ProgSnap2 default.
@@ -2214,7 +2228,7 @@ def export(
         ),
     ] = False,
 ):
-    """Export the learnlog repository."""
+    """Export the learnlog repository as a .learnlog bundle."""
     workdir = resolve_workdir(directory)
     repo = LearnlogRepo(workdir)
 
@@ -2238,7 +2252,7 @@ def test_export_command(workdir, monkeypatch):
     repo = LearnlogRepo(workdir)
     monkeypatch.chdir(workdir)
     runner = CliRunner()
-    bundle = workdir / "out.bundle"
+    bundle = workdir / "out.learnlog"
     result = runner.invoke(
         app, ["export", "-o", str(bundle)]
     )
@@ -3039,9 +3053,9 @@ def play(
         typer.Option(
             "--from", "-f",
             help=(
-                "Source: directory with .learnlog/ "
-                "a ProgSnap2 zip, or a .bundle file. "
-                "Defaults to current directory."
+                "Source: directory with .learnlog/, "
+                "a ProgSnap2 zip, or a .learnlog bundle "
+                "file. Defaults to current directory."
             ),
         ),
     ] = None,
@@ -3354,8 +3368,8 @@ def analyse(
             "--from", "-f",
             help=(
                 "Source: ProgSnap2 zip file, "
-                "directory with .learnlog/, "
-                "or a .bundle file. "
+                "directory with .learnlog/, or a "
+                ".learnlog bundle file. "
                 "Defaults to current directory."
             ),
         ),

--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -503,11 +503,11 @@ using [[sys.executable]] to create [[.venv/]] would bind
 the student's project to pipx's hidden interpreter, which
 is not under the student's control and may be upgraded or
 removed when pipx is.  Second, asking pipx's interpreter
-about PEP 668 (\cref{sec:setup-pep668}) always reports
-\enquote{not managed} regardless of the host distro,
-because virtual environments never carry the
-[[EXTERNALLY-MANAGED]] marker; the student's system Python
-may be externally managed even when pipx's is not.
+about PEP 668 always reports \enquote{not managed}
+regardless of the host distro, because virtual environments
+never carry the [[EXTERNALLY-MANAGED]] marker; the student's
+system Python may be externally managed even when pipx's is
+not.
 
 Picking a target interpreter by name avoids both problems.
 The default [[python3]] matches what almost every student

--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -4,19 +4,21 @@
 The [[learnlog]] command lets students prepare projects for
 logging and lets both students and teachers manage and review
 the development logs that are produced.
-It provides eleven subcommands: [[init]] prepares a project
+It provides thirteen subcommands: [[init]] prepares a project
 directory (creating [[.learnlog/]] and installing [[learnlog]]
-for the student's chosen language), [[list]] gives a compact
-overview of the recorded commits, [[export]] creates a portable
-bundle of the log (or a ProgSnap2 dataset for CS education
-analysis), [[set-remote]], [[push]], [[clone]], and [[pull]]
-manage synchronisation with a remote Git repository, [[git]]
-forwards Git commands to the log repository, [[tag]] manages
-named markers in the log (such as [[lab1]] or [[lab2]]),
-[[play]] gives an interactive viewer for browsing the commit
-history, and [[analyse]] generates \LaTeX{} reports of
-edit--run cycles from a ProgSnap2 dataset, optionally filtered
-by a [[Column=Regex]] range.
+for the student's chosen language), [[activate]] and
+[[deactivate]] emit shell code for entering or leaving the
+project [[.venv/]], [[list]] gives a compact overview of the
+recorded commits, [[export]] creates a portable bundle of the
+log (or a ProgSnap2 dataset for CS education analysis),
+[[set-remote]], [[push]], [[clone]], and [[pull]] manage
+synchronisation with a remote Git repository, [[git]] forwards
+Git commands to the log repository, [[tag]] manages named
+markers in the log (such as [[lab1]] or [[lab2]]), [[play]]
+gives an interactive viewer for browsing the commit history,
+and [[analyse]] generates \LaTeX{} reports of edit--run
+cycles from a ProgSnap2 dataset, optionally filtered by a
+[[Column=Regex]] range.
 
 We use Typer for the CLI framework because it gives us type-checked
 arguments with minimal boilerplate, and the modern
@@ -30,13 +32,14 @@ arguments with minimal boilerplate, and the modern
 
 Provides the ``learnlog`` command with subcommands for setting
 up a project to record with learnlog (``init``), running Git
-commands against the log, exporting it as a bundle or
-ProgSnap2 dataset, cloning from and synchronising with a remote
-repository, playing back the development log stored in
-``.learnlog/``, and analysing ProgSnap2 datasets to produce
-LaTeX reports of student edit--run cycles.  The ``analyse``
-command accepts ``Column=Regex`` range boundaries to restrict
-analysis to a subset of events.
+commands against the log, emitting shell code to activate or
+deactivate the project ``.venv/``, exporting the log as a
+bundle or ProgSnap2 dataset, cloning from and synchronising
+with a remote repository, playing back the development log
+stored in ``.learnlog/``, and analysing ProgSnap2 datasets to
+produce LaTeX reports of student edit--run cycles.  The
+``analyse`` command accepts ``Column=Regex`` range boundaries
+to restrict analysis to a subset of events.
 """
 
 <<imports>>
@@ -54,6 +57,7 @@ import tempfile
 import os
 import io
 import pathlib
+import shlex
 import subprocess
 import sys
 import datetime
@@ -82,6 +86,7 @@ import enum
 import os
 import pathlib
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -487,6 +492,36 @@ class Language(str, enum.Enum):
 @
 
 
+\subsection{Selecting shell syntax}
+\label{sec:shell-syntax}
+
+The new [[activate]] and [[deactivate]] commands do not mutate the
+parent shell directly; they print shell code for the caller to
+[[eval]].  We therefore model the output syntax as an enum in the
+same way as [[Language]] above: Typer turns enum members into
+validated [[--shell]] choices automatically, and adding [[zsh]],
+[[fish]], or PowerShell later becomes a local change rather than a
+stringly-typed special case.
+
+For now we keep the surface intentionally small and only support
+[[bash]].  That matches the documented usage pattern
+[[eval "$(learnlog activate)"]], and it keeps the first
+implementation honest about which shell semantics we actually emit.
+
+<<constants>>=
+class Shell(str, enum.Enum):
+    """Supported shell syntaxes for emitted activation code.
+
+    Used by ``learnlog activate`` and
+    ``learnlog deactivate``.  New members become valid
+    ``--shell`` choices automatically via Typer's built-in
+    enum support.
+    """
+
+    bash = "bash"
+@
+
+
 \subsection{Resolving the target Python}
 \label{sec:setup-target-python}
 
@@ -632,6 +667,198 @@ def test_find_in_venv_errors_when_absent(tmp_path):
     from learnlog.cli import find_in_venv
     with pytest.raises(SystemExit, match="No pip found"):
         find_in_venv(tmp_path, "pip")
+@
+
+
+\subsection{Resolving the project [[.venv/]]}
+\label{sec:project-venv}
+
+The new shell-emitting commands intentionally ignore any unrelated
+[[VIRTUAL_ENV]] in the caller.  Their job is narrower: find the
+enclosing learnlog project and talk about the project-local
+[[.venv/]] that lives next to [[.learnlog/]].  That makes the
+behavior predictable from any subdirectory and avoids accidentally
+deactivating or activating some other environment the user happened
+to have open.
+
+We therefore build on [[resolve_workdir()]] and then require a
+[[.venv/]] sibling.  A missing [[.venv/]] is not something the
+shell command can repair on its own, so we fail with a direct
+message that points back at [[learnlog init python]].
+
+<<helper functions>>=
+def resolve_project_venv(directory=None):
+    """Return the project-local ``.venv/`` for a learnlog project.
+
+    The project is resolved the same way as other commands: use the
+    explicit directory when provided, otherwise search upward from the
+    current working directory for ``.learnlog/``.  The returned path is
+    always ``<project>/.venv`` and must already exist.
+    """
+    workdir = resolve_workdir(directory)
+    venv_dir = (workdir / ".venv").resolve()
+    if not venv_dir.is_dir():
+        raise SystemExit(
+            f"No project .venv/ directory in {workdir}. "
+            "Run 'learnlog init python' first."
+        )
+    return venv_dir
+@
+
+Let's verify both the success path and the missing-venv error:
+
+<<test functions>>=
+def test_resolve_project_venv_returns_local_venv(workdir):
+    """The project-local .venv/ is returned."""
+    from learnlog.cli import resolve_project_venv
+    repo = LearnlogRepo(workdir)
+    venv_dir = workdir / ".venv"
+    venv_dir.mkdir()
+    assert resolve_project_venv(workdir) == venv_dir.resolve()
+
+def test_resolve_project_venv_errors_when_missing(workdir):
+    """A learnlog project without .venv/ is rejected."""
+    from learnlog.cli import resolve_project_venv
+    repo = LearnlogRepo(workdir)
+    with pytest.raises(SystemExit, match="No project .venv/"):
+        resolve_project_venv(workdir)
+@
+
+
+\subsection{Quoting shell arguments safely}
+
+Because [[activate]] and [[deactivate]] print shell code to be
+evaluated later, every path we interpolate must already be quoted for
+the target shell.  For [[bash]] the right primitive is
+[[shlex.quote()]]: it produces a single shell word regardless of
+spaces or punctuation in the underlying path.
+
+<<helper functions>>=
+def shell_quote(text, shell):
+    """Return ``text`` quoted as one word for ``shell``."""
+    if shell is Shell.bash:
+        return shlex.quote(str(text))
+    raise AssertionError(f"Unsupported shell: {shell}")
+@
+
+<<test functions>>=
+def test_shell_quote_bash_handles_spaces():
+    """Bash quoting preserves spaces inside one shell word."""
+    from learnlog.cli import Shell, shell_quote
+    assert shell_quote("/tmp/project dir/.venv", Shell.bash) == (
+        "'/tmp/project dir/.venv'"
+    )
+@
+
+
+\subsection{Emitting activation code for [[bash]]}
+\label{sec:emit-activation}
+
+The shell commands cannot directly change the caller's environment, so
+they print the code the caller should evaluate.  For [[bash]],
+activation delegates to the venv's own [[activate]] script instead of
+re-implementing [[PATH]], [[PS1]], and shell functions ourselves.  The
+virtual environment already knows how to install its [[deactivate]]
+function and restore shell state correctly, so sourcing it is both the
+minimal and the most correct option.
+
+The emitted code is intentionally just one command: source the project
+[[activate]] script.  If the script is missing even though [[.venv/]]
+exists, the venv is incomplete and we fail early rather than emitting
+broken shell code.
+
+<<helper functions>>=
+def activation_script(venv_dir, shell):
+    """Return the activation script path for ``venv_dir`` and ``shell``."""
+    if shell is Shell.bash:
+        script = venv_dir / "bin" / "activate"
+    else:
+        raise AssertionError(f"Unsupported shell: {shell}")
+    if not script.is_file():
+        raise SystemExit(
+            f"No activation script found for {shell.value} in {venv_dir}"
+        )
+    return script
+
+
+def emit_activate_shell_code(venv_dir, shell):
+    """Return shell code that activates ``venv_dir``."""
+    script = activation_script(venv_dir, shell)
+    if shell is Shell.bash:
+        return f"source {shell_quote(script, shell)}"
+    raise AssertionError(f"Unsupported shell: {shell}")
+@
+
+<<test functions>>=
+def test_activation_script_returns_bash_activate(workdir):
+    """Bash activation uses .venv/bin/activate."""
+    from learnlog.cli import Shell, activation_script
+    repo = LearnlogRepo(workdir)
+    activate = workdir / ".venv" / "bin" / "activate"
+    activate.parent.mkdir(parents=True)
+    activate.write_text("")
+    assert activation_script(workdir / ".venv", Shell.bash) == activate
+
+def test_activation_script_errors_when_missing(workdir):
+    """A broken .venv/ without activate script is rejected."""
+    from learnlog.cli import Shell, activation_script
+    repo = LearnlogRepo(workdir)
+    (workdir / ".venv").mkdir()
+    with pytest.raises(SystemExit, match="No activation script"):
+        activation_script(workdir / ".venv", Shell.bash)
+
+def test_emit_activate_shell_code_bash_quotes_path(workdir):
+    """Bash activation code sources the quoted activate script."""
+    from learnlog.cli import Shell, emit_activate_shell_code
+    repo = LearnlogRepo(workdir)
+    venv_dir = workdir / ".venv with space"
+    activate = venv_dir / "bin" / "activate"
+    activate.parent.mkdir(parents=True)
+    activate.write_text("")
+    assert emit_activate_shell_code(venv_dir, Shell.bash) == (
+        f"source {shlex.quote(str(activate))}"
+    )
+@
+
+
+\subsection{Emitting deactivation code for [[bash]]}
+\label{sec:emit-deactivation}
+
+Deactivation is intentionally more conservative than activation.
+Calling [[deactivate]] blindly would tear down whichever venv happens
+to be active in the shell, even if it has nothing to do with the
+current learnlog project.  Instead we emit a guard that compares the
+current [[VIRTUAL_ENV]] against the resolved project [[.venv/]] and
+only then calls the shell function installed by venv activation.
+
+That means [[learnlog deactivate]] is meant to be used after
+[[learnlog activate]] (or after an equivalent manual activation of the
+same project [[.venv/]]).  If no matching venv is active, the emitted
+code becomes a no-op.
+
+<<helper functions>>=
+def emit_deactivate_shell_code(venv_dir, shell):
+    """Return shell code that deactivates ``venv_dir`` if active."""
+    quoted_venv = shell_quote(venv_dir, shell)
+    if shell is Shell.bash:
+        return (
+            f'if [ "${{VIRTUAL_ENV:-}}" = {quoted_venv} ] '
+            f'&& declare -F deactivate >/dev/null; then deactivate; fi'
+        )
+    raise AssertionError(f"Unsupported shell: {shell}")
+@
+
+<<test functions>>=
+def test_emit_deactivate_shell_code_bash_guards_venv(workdir):
+    """Bash deactivation only targets the matching project venv."""
+    from learnlog.cli import Shell, emit_deactivate_shell_code
+    repo = LearnlogRepo(workdir)
+    venv_dir = (workdir / ".venv").resolve()
+    assert emit_deactivate_shell_code(venv_dir, Shell.bash) == (
+        "if [ \"${VIRTUAL_ENV:-}\" = "
+        f"{shlex.quote(str(venv_dir))}"
+        " ] && declare -F deactivate >/dev/null; then deactivate; fi"
+    )
 @
 
 
@@ -1214,7 +1441,7 @@ def test_init_python_invokes_write_autostart_files(
 
 \section{Typer application}
 
-We define the Typer app at module level with eleven
+We define the Typer app at module level with thirteen
 commands.
 The [[app]] object is the entry point referenced by
 [[pyproject.toml]].
@@ -1331,6 +1558,232 @@ def test_init_rejects_unknown_language(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     result = CliRunner().invoke(app, ["init", "java"])
     assert result.exit_code != 0
+@
+
+
+\subsection{The [[activate]] command}
+\label{sec:activate-command}
+
+The command name is intentionally a little deceptive: it does not, and
+cannot, activate the parent shell directly.  Like any other subprocess,
+[[learnlog]] can only affect its own environment.  The correct interface
+is therefore to print shell code and let the caller evaluate it:
+[[eval "$(learnlog activate)"]].
+
+We make that usage explicit in the help text because a plain
+[[learnlog activate]] would only print the [[source .../bin/activate]]
+command instead of running it.  The optional [[--shell]] argument is an
+enum, currently with only [[bash]], so the surface is honest about the
+syntax we emit while still leaving a clean extension point for more
+shells later.
+
+<<typer commands>>=
+@app.command(
+    name="activate",
+    help=(
+        "Print shell code that activates the project .venv/. "
+        "Use it as: eval \"$(learnlog activate)\".  "
+        "Running 'learnlog activate' by itself only prints "
+        "the command because a subprocess cannot change the "
+        "parent shell environment."
+    ),
+)
+def activate(
+    shell: Annotated[
+        Shell,
+        typer.Option(
+            "--shell",
+            help=(
+                "Shell syntax to emit.  Use with eval, "
+                "for example: eval \"$(learnlog activate)\"."
+            ),
+        ),
+    ] = Shell.bash,
+):
+    """Print shell code for `eval "$(learnlog activate)"`.
+
+    This command does not mutate the current shell directly.
+    Instead it prints shell code that the caller should
+    evaluate, normally as ``eval "$(learnlog activate)"``.
+    """
+    typer.echo(
+        emit_activate_shell_code(
+            resolve_project_venv(), shell,
+        )
+    )
+@
+
+<<test functions>>=
+def test_activate_command_prints_bash_code(workdir, monkeypatch):
+    """The activate command prints shell code for the project .venv/."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    repo = LearnlogRepo(workdir)
+    project = workdir / "course project"
+    project.mkdir()
+    LearnlogRepo(project)
+    activate = project / ".venv" / "bin" / "activate"
+    activate.parent.mkdir(parents=True)
+    activate.write_text("")
+    monkeypatch.chdir(project)
+    result = CliRunner().invoke(app, ["activate"])
+    assert result.exit_code == 0
+    assert result.output.strip() == (
+        f"source {shlex.quote(str(activate))}"
+    )
+
+def test_activate_command_finds_project_from_subdir(
+    workdir, monkeypatch,
+):
+    """Activation resolves the enclosing project from a subdirectory."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    repo = LearnlogRepo(workdir)
+    activate = workdir / ".venv" / "bin" / "activate"
+    activate.parent.mkdir(parents=True)
+    activate.write_text("")
+    nested = workdir / "src" / "lab1"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    result = CliRunner().invoke(app, ["activate", "--shell", "bash"])
+    assert result.exit_code == 0
+    assert result.output.strip() == (
+        f"source {shlex.quote(str(activate))}"
+    )
+
+def test_activate_command_errors_without_project(tmp_path, monkeypatch):
+    """Activation fails clearly outside a learnlog project."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(app, ["activate"])
+    assert result.exit_code == 1
+    assert "No .learnlog/ directory found." in result.output
+
+def test_activate_command_errors_without_project_venv(
+    workdir, monkeypatch,
+):
+    """Activation requires the sibling project .venv/."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    repo = LearnlogRepo(workdir)
+    monkeypatch.chdir(workdir)
+    result = CliRunner().invoke(app, ["activate"])
+    assert result.exit_code == 1
+    assert "Run 'learnlog init python' first." in result.output
+
+def test_activate_help_mentions_eval_pattern():
+    """The help text documents the intended eval-based usage."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    result = CliRunner().invoke(app, ["activate", "--help"])
+    assert result.exit_code == 0
+    assert 'eval "$(learnlog activate)"' in result.output
+    assert "--shell" in result.output
+    assert "bash" in result.output
+@
+
+
+\subsection{The [[deactivate]] command}
+\label{sec:deactivate-command}
+
+The dual command follows the same shell-emitting contract as
+[[activate]]: it prints code that the caller should run via
+[[eval "$(learnlog deactivate)"]].  The difference is that the code
+is guarded.  Deactivation should only happen when the active venv is
+the current project's [[.venv/]], otherwise a user standing inside a
+learnlog project but working in some other environment would lose that
+unrelated shell state unexpectedly.
+
+As with [[activate]], the help text states the [[eval]] pattern
+directly so the intended usage is visible in [[--help]].
+
+<<typer commands>>=
+@app.command(
+    name="deactivate",
+    help=(
+        "Print shell code that deactivates the project .venv/ "
+        "when it is the active venv.  Use it as: "
+        "eval \"$(learnlog deactivate)\".  Running "
+        "'learnlog deactivate' by itself only prints the "
+        "command because a subprocess cannot change the "
+        "parent shell environment."
+    ),
+)
+def deactivate(
+    shell: Annotated[
+        Shell,
+        typer.Option(
+            "--shell",
+            help=(
+                "Shell syntax to emit.  Use with eval, "
+                "for example: eval \"$(learnlog deactivate)\"."
+            ),
+        ),
+    ] = Shell.bash,
+):
+    """Print shell code for `eval "$(learnlog deactivate)"`.
+
+    The emitted code is a guarded no-op unless the active
+    ``$VIRTUAL_ENV`` matches the current project's
+    ``.venv/``.
+    """
+    typer.echo(
+        emit_deactivate_shell_code(
+            resolve_project_venv(), shell,
+        )
+    )
+@
+
+<<test functions>>=
+def test_deactivate_command_prints_guarded_bash_code(
+    workdir, monkeypatch,
+):
+    """The deactivate command only targets the project .venv/."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    repo = LearnlogRepo(workdir)
+    venv_dir = workdir / ".venv"
+    venv_dir.mkdir()
+    monkeypatch.chdir(workdir)
+    result = CliRunner().invoke(app, ["deactivate"])
+    assert result.exit_code == 0
+    assert result.output.strip() == (
+        "if [ \"${VIRTUAL_ENV:-}\" = "
+        f"{shlex.quote(str(venv_dir.resolve()))}"
+        " ] && declare -F deactivate >/dev/null; then deactivate; fi"
+    )
+
+def test_deactivate_command_errors_without_project(tmp_path, monkeypatch):
+    """Deactivation fails clearly outside a learnlog project."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(app, ["deactivate"])
+    assert result.exit_code == 1
+    assert "No .learnlog/ directory found." in result.output
+
+def test_deactivate_command_errors_without_project_venv(
+    workdir, monkeypatch,
+):
+    """Deactivation requires the sibling project .venv/."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    repo = LearnlogRepo(workdir)
+    monkeypatch.chdir(workdir)
+    result = CliRunner().invoke(app, ["deactivate"])
+    assert result.exit_code == 1
+    assert "Run 'learnlog init python' first." in result.output
+
+def test_deactivate_help_mentions_eval_pattern():
+    """The help text documents the intended eval-based usage."""
+    from learnlog.cli import app
+    from typer.testing import CliRunner
+    result = CliRunner().invoke(app, ["deactivate", "--help"])
+    assert result.exit_code == 0
+    assert 'eval "$(learnlog deactivate)"' in result.output
+    assert "--shell" in result.output
+    assert "bash" in result.output
 @
 
 

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -1,15 +1,36 @@
 \chapter{Overview}
 \label{learnlog}
 
-The [[learnlog]] package provides automatic logging of student code
+The [[learnlog]] package provides automatic logging of code
 development.
-A one-time \mintinline{bash}{pipx install learnlog} puts the tool on
-the student's [[PATH]]; running
-\mintinline{bash}{learnlog init python} in a project directory then
-creates a hidden Git repository alongside a virtual environment wired
+The aim is to be independent of any particular IDE or editor.
+We just need the core language constructs of the programming language, for 
+instance Python.
+So this should work seamlessly in Vim (and Emacs), VSCode, IDLE or even web 
+services like Repl.it.
+
+\section{Installation and setup}
+
+Installation is rather simple:
+\begin{minted}{bash}
+pipx install learnlog
+\end{minted}
+This one-time line puts the tool on the [[PATH]].
+In VSCode and Repl.it that have a built-in virtual environment automatically, 
+one can go for the per-project installation instead, with
+\mintinline{bash}{pip install learnlog} (no x in pip)
+in the project venv.
+
+Then we can use the [[learnlog]] tool to activate it in any project:
+\begin{minted}{bash}
+cd the-project-directory
+learnlog init python
+\end{minted}
+Running \mintinline{bash}{learnlog init python} in a project directory creates 
+a hidden Git repository alongside a virtual environment wired
 so that every subsequent Python run through that venv is captured
 automatically.
-When a script runs, the autostart hook triggers a chain of actions: it
+When a script runs, an autostart hook triggers a chain of actions: it
 detects which script is running, stages any source code changes into
 the hidden Git repository, wraps the standard streams to capture all
 I/O, and registers cleanup handlers that finalise the log entry when
@@ -22,39 +43,98 @@ student can still opt in explicitly by adding
 file.
 The same capture machinery runs; it is just triggered by the import
 rather than by the autostart hook.
+The limitation of this method is that it can't capture [[SyntaxError]]s that 
+occur in the same file as the import line.
 
-These logs serve two main use cases.
+\section{The use cases}
 
-\paragraph{Sharing live-coding sessions.}
+We see three main use cases:
+\begin{enumerate}
+\item Teachers tracking their live coding sessions to later share with 
+students, so that students can play back and check out different versions of 
+the code easily.
+\item Students logging their own work to review later.
+This will help them debug, see what they have tried---particularly, show a TA 
+what they've tried when asking for help.
+\item Researchers studying how students code, by asking students to share their 
+logs and then analysing the edit--run cycles.
+\end{enumerate}
+
+\subsection{Sharing live-coding sessions}
+
+The teacher will likely create some directory for code written live during the 
+lectures of the course.
+It will be the least work for having such a folder per course, not per 
+lecture---less likely to forget a recording too.
+\begin{minted}{bash}
+mkdir -p ~/teaching/prgi26
+cd ~/teaching/prgi26
+learnlog init python
+\end{minted}
+
 After \mintinline{bash}{learnlog init python} in the demo project,
 every run during a lecture or tutorial is recorded automatically---no
 code changes to the demonstration scripts are needed.
+However, this requires that the Python venv (virtual environment) is activated!
+Tools like VSCode automatically activates the venv.
+
+To publish the recoded sessions, we can simply push the hidden Git repository 
+to a shared remote.
 After the session, the teacher points the log at a remote
 repository and pushes:
 \begin{minted}{bash}
-learnlog set-remote git@gitlab.kth.se:dbosk/lecture01.git
+learnlog set-remote git@github.com:dbosk/prgi26.git
 learnlog push
 \end{minted}
 Students then clone the log and replay it step by step:
 \begin{minted}{bash}
-learnlog clone git@gitlab.kth.se:dbosk/lecture01.git
+learnlog clone git@github.com:dbosk/prgi26.git
+cd prgi26
 learnlog play
 \end{minted}
 They see the exact sequence of code changes, inputs, and outputs
 from the demonstration.
 
+At the start of the next class, the teacher runs
+\begin{minted}{bash}
+learnlog tag lecture02
+\end{minted}
+And at the end of the class, the teacher runs
+\begin{minted}{bash}
+learnlog push
+\end{minted}
+Then the students run
+\begin{minted}{bash}
+learnlog pull
+learnlog play lecture02
+\end{minted}
+The students can run
+\begin{minted}{bash}
+learnlog tag
+\end{minted}
+to see the available tags and check out the lecture they want to review.
+
 Alternatively, when a shared Git remote is not available, the
 teacher can export the log as a portable bundle file:
 \begin{minted}{bash}
-learnlog export -o lecture01.bundle
+learnlog export -o lecture01.learnlog
 \end{minted}
 The teacher distributes the file (\eg via a course page) and
 students replay it directly:
 \begin{minted}{bash}
-learnlog play -f lecture01.bundle
+learnlog play -f lecture01.learnlog
 \end{minted}
+When the teacher wants to publish the second lecture, they don't want to 
+include the first lecture again.
+They can export only the new commits since the last tag:
+\begin{minted}{bash}
+learnlog export -o lecture02.learnlog lecture02
+\end{minted}
+This only works if they ran \mintinline{bash}{learnlog tag lecture02} at the 
+start of the second lecture, as described above.
 
-\paragraph{Studying how students code.}
+\subsection{Studying how students code}
+
 A researcher (or teacher) creates an empty Git repository for each
 student---for instance, one repository per student on a shared
 server.
@@ -92,7 +172,8 @@ This gives a complete timeline of how students develop and debug
 their code---useful for research purposes or to help students
 refine their debugging techniques.
 
-\paragraph{A student-facing onboarding page.}
+\subsection{A student-facing onboarding page.}
+
 Both use cases above assume students have already installed
 [[learnlog]] with \mintinline{bash}{pipx} and run
 \mintinline{bash}{learnlog init python} in the project directory.

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -414,6 +414,35 @@ We map those sentinel forms to labels that explain how Python was
 started while leaving ordinary filenames and entry-point basenames
 unchanged.
 
+The same bootstrap exclusion from the autostart gate also needs to be
+enforced here.
+The [[.pth]] hook skips [[learnlog init]] before importing the package,
+but the installed CLI entry point imports [[learnlog.cli]], which in turn
+imports [[learnlog]] through ordinary Python package loading.
+Without a second check in [[initialize]], [[learnlog init]] still logs
+itself whenever the CLI package is imported directly.
+
+We therefore keep the bootstrap detector in the shared runtime helpers,
+then reuse the same predicate from [[_autostart.py]].
+That avoids the drift that would come from maintaining two slightly
+different definitions of what counts as the bootstrap invocation.
+
+<<functions>>=
+def _is_learnlog_init(argv):
+    """True iff ``argv`` looks like a ``learnlog init`` invocation.
+
+    Recognises the installed ``learnlog`` entry-point script and
+    ``python -m learnlog`` (in which case ``argv[0]`` contains
+    ``learnlog`` as a path component).
+    """
+    if len(argv) < 2 or argv[1] != "init":
+        return False
+    basename = os.path.basename(argv[0])
+    if basename == "learnlog":
+        return True
+    return "learnlog" in pathlib.PurePath(argv[0]).parts
+@
+
 <<functions>>=
 def _normalize_main_invocation(argv):
     """Return a normalised ``(script, args)`` pair from ``argv``."""
@@ -562,6 +591,8 @@ def initialize():
 @
 
 <<detect main script>>=
+if _is_learnlog_init(sys.argv):
+    return
 main_script, main_args = _normalize_main_invocation(sys.argv)
 start_time = datetime.datetime.now()
 project_root = os.environ.get("LEARNLOG_PROJECT_ROOT")
@@ -729,6 +760,23 @@ class TestInitialize:
         )
         msg = git_result.stdout
         assert msg.count("stdin: hello\n") == 1
+
+    def test_skips_learnlog_init_bootstrap(self, tmp_path, test_env):
+        script = tmp_path / "learnlog"
+        script.write_text(
+            "import sys\n"
+            "sys.argv = ['/venv/bin/learnlog', 'init', 'python']\n"
+            "import learnlog\n"
+            "print(learnlog.repo)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(tmp_path), env=test_env,
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == "None"
+        assert not (tmp_path / ".learnlog").exists()
 
     def test_uses_existing_repo_from_subdirectory(
         self, workdir, test_env
@@ -1205,6 +1253,7 @@ filesystem wholesale.
 import os
 import sys
 import pathlib
+import sysconfig
 
 <<autostart marker location>>
 <<autostart gate helpers>>
@@ -1251,17 +1300,38 @@ marker.
 It was set deliberately; the backup's match is coincidental and
 the marker's project is what the student actually worked on.
 
-The marker path is fixed once the module is installed: the
-[[.pth]] file and the marker are both written into
-[[site-packages]] by [[learnlog init]], and the
-[[_autostart.py]] module lives one level down inside the
-[[learnlog]] package.
+The marker belongs to the current interpreter's [[purelib]]
+directory, not necessarily next to the imported module file.
+That distinction matters in editable and source-tree installs:
+the [[.pth]] hook still lives in [[site-packages]], but it can
+import [[learnlog._autostart]] from a checkout under [[src/]].
+So we ask [[sysconfig]] for this interpreter's [[purelib]] path
+and only fall back to a module-relative guess if that lookup
+fails.
 
 <<autostart marker location>>=
-_DEFAULT_MARKER_PATH = (
-    pathlib.Path(__file__).parent.parent
-    / "learnlog_project_root.txt"
-)
+def _default_marker_path(module_file=None, purelib_path=None):
+    """Return the marker path for this interpreter.
+
+    The marker is written into ``site-packages`` alongside the
+    autostart ``.pth`` file.  Editable installs may import
+    ``learnlog._autostart`` from a source tree instead, so the
+    module's own directory is only a fallback.
+    """
+    if purelib_path is None:
+        try:
+            purelib_path = pathlib.Path(
+                sysconfig.get_paths()["purelib"]
+            )
+        except Exception:
+            module_path = pathlib.Path(
+                module_file or __file__
+            ).resolve()
+            purelib_path = module_path.parent.parent
+    return pathlib.Path(purelib_path) / "learnlog_project_root.txt"
+
+
+_DEFAULT_MARKER_PATH = _default_marker_path()
 @
 
 Reading the marker is best-effort: the file may be absent
@@ -1387,19 +1457,7 @@ itself (installed in [[<venv>/bin/]]) or a path to the package's
 both contain [[learnlog]] as a path component.
 
 <<autostart gate helpers>>=
-def _is_learnlog_init(argv):
-    """True iff ``argv`` looks like a ``learnlog init`` invocation.
-
-    Recognises the installed ``learnlog`` entry-point script and
-    ``python -m learnlog`` (in which case ``argv[0]`` contains
-    ``learnlog`` as a path component).
-    """
-    if len(argv) < 2 or argv[1] != "init":
-        return False
-    basename = os.path.basename(argv[0])
-    if basename == "learnlog":
-        return True
-    return "learnlog" in pathlib.PurePath(argv[0]).parts
+from learnlog import _is_learnlog_init
 @
 
 
@@ -1494,6 +1552,12 @@ Without this separation, merely importing the helper module would leak
 [[LEARNLOG_PROJECT_ROOT]] into the parent pytest process and redirect
 later subprocesses into the wrong project.
 
+The development checkout adds one more regression worth freezing in a
+test: the default marker path must come from the current interpreter's
+[[site-packages]], not from the repository [[src/]] tree.
+Otherwise an editable install will self-heal the marker into the
+checkout and leave behind a misleading untracked file.
+
 <<autostart test functions>>=
 def test_importing_autostart_module_has_no_side_effects(monkeypatch):
     monkeypatch.delenv("LEARNLOG_PROJECT_ROOT", raising=False)
@@ -1503,6 +1567,17 @@ def test_importing_autostart_module_has_no_side_effects(monkeypatch):
     importlib.reload(autostart)
 
     assert "LEARNLOG_PROJECT_ROOT" not in os.environ
+
+
+def test_default_marker_path_uses_current_purelib():
+    import learnlog._autostart as autostart
+
+    expected = (
+        pathlib.Path(sysconfig.get_paths()["purelib"])
+        / "learnlog_project_root.txt"
+    )
+
+    assert autostart._DEFAULT_MARKER_PATH == expected
 @
 
 <<test [[_autostart.py]]>>=
@@ -1513,6 +1588,7 @@ import pytest
 import select
 import subprocess
 import sys
+import sysconfig
 
 from learnlog._autostart import _should_activate
 
@@ -1754,6 +1830,16 @@ tree.
 Naming that extra file [[000-learnlog-source.pth]] makes [[site.py]]
 add the source tree before it reaches [[learnlog-autostart.pth]], so the
 autostart import resolves to the code under test.
+For the one case that must look like the installed [[learnlog]] console
+script, we also drop a tiny launcher into the venv's [[bin/]] directory.
+It uses the venv's own [[python]] in its shebang, so the subprocess still
+exercises the same interpreter and [[site-packages]] that the rest of the
+autostart smoke tests use.
+The body stays deliberately minimal: it only imports [[learnlog]], because
+this test is about bootstrap exclusion inside [[initialize]], not about
+the CLI's dependency stack.
+That gives the gate the real [[argv[0] == learnlog]] shape without
+turning the test into a packaging/install exercise.
 
 <<autostart test helpers>>=
 def _repo_root():
@@ -1795,6 +1881,13 @@ def _prepare_autostart_project(tmp_path):
     source_pth = purelib / "000-learnlog-source.pth"
     source_pth.write_text(str((_repo_root() / "src").resolve()) + "\n")
     cli.write_autostart_files(venv_dir, project)
+    python = cli.find_in_venv(venv_dir, "python")
+    learnlog = python.parent / "learnlog"
+    learnlog.write_text(
+        f"#!{python}\n"
+        "import learnlog\n"
+    )
+    learnlog.chmod(0o755)
 
     return project, venv_dir
 
@@ -1811,6 +1904,20 @@ def _git_history(project):
     result = subprocess.run(
         ["git", "--git-dir=.learnlog", "--work-tree=.",
          "log", "--format=%B"],
+        cwd=str(project),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    return result.stdout
+
+
+def _latest_commit_message(project):
+    """Return the latest commit body in the learnlog repo."""
+    result = subprocess.run(
+        ["git", "--git-dir=.learnlog", "--work-tree=.",
+         "log", "-1", "--format=%B"],
         cwd=str(project),
         capture_output=True,
         text=True,
@@ -1951,10 +2058,66 @@ def test_autostart_captures_common_invocations(tmp_path):
     assert "stdin: hello from tty\n" in history
 @
 
+The last naming-sensitive cases are console-style wrappers whose
+[[argv[0]]] is neither [[-c]] nor a [[.py]] file.
+We synthesise a tiny script named [[pytest]] and a tiny venv-local
+[[learnlog]] launcher so the real [[.pth]] hook sees the same basename
+shapes as the installed entry points.
+That keeps the test focused on autostart's gate and script-name
+normalisation without turning it into a second packaging test.
+
+<<autostart test functions>>=
+def test_autostart_captures_named_entry_points(tmp_path):
+    project, venv_dir = _prepare_autostart_project(tmp_path)
+    env = _autostart_env()
+    python = _venv_binary(venv_dir, "python")
+    learnlog = _venv_binary(venv_dir, "learnlog")
+    pytest_script = tmp_path / "pytest"
+    learnlog_script = tmp_path / "learnlog"
+
+    pytest_script.write_text("print('pytest wrapper')\n")
+    learnlog_script.write_text("print('learnlog wrapper')\n")
+
+    subprocess.run(
+        [str(python), str(pytest_script), "--version"],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    assert "Script: pytest" in _latest_commit_message(project)
+
+    subprocess.run(
+        [str(python), str(learnlog_script), "play"],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    after_play = _latest_commit_message(project)
+    assert "Script: learnlog" in after_play
+    assert "Arguments: play" in after_play
+
+    subprocess.run(
+        [str(learnlog), "init", "python", "--help"],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    assert _latest_commit_message(project) == after_play
+@
+
 The REPL path is the remaining truly interactive case.
 CPython reads top-level statements through [[readline]] on the TTY,
-not through [[sys.stdin]], so the only way to verify our history-diff
-approach is to drive a real REPL over a pseudoterminal.
+not through [[sys.stdin]], so the only way to verify the inline
+[[pyrepl]] hook is to drive a real REPL over a pseudoterminal.
 
 <<autostart test functions>>=
 @pytest.mark.skipif(

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -3,20 +3,32 @@
 
 The [[learnlog]] package provides automatic logging of student code
 development.
-Students add \mintinline{python}{import learnlog} as the first line of
-their Python files.
-When the program runs, the import triggers a chain of actions: it
-detects which script is running, stages any source code changes into a
-hidden Git repository, wraps the standard streams to capture all I/O,
-and registers cleanup handlers that finalise the log entry when the
-program exits.
+A one-time \mintinline{bash}{pipx install learnlog} puts the tool on
+the student's [[PATH]]; running
+\mintinline{bash}{learnlog init python} in a project directory then
+creates a hidden Git repository alongside a virtual environment wired
+so that every subsequent Python run through that venv is captured
+automatically.
+When a script runs, the autostart hook triggers a chain of actions: it
+detects which script is running, stages any source code changes into
+the hidden Git repository, wraps the standard streams to capture all
+I/O, and registers cleanup handlers that finalise the log entry when
+the program exits.
+
+When no virtual environment is available---or when [[learnlog init]]
+cannot create one (restricted lab machines, ephemeral graders)---the
+student can still opt in explicitly by adding
+\mintinline{python}{import learnlog} as the first line of the Python
+file.
+The same capture machinery runs; it is just triggered by the import
+rather than by the autostart hook.
 
 These logs serve two main use cases.
 
 \paragraph{Sharing live-coding sessions.}
-A teacher adds \mintinline{python}{import learnlog} to the
-demonstration scripts used during a lecture or tutorial.
-Every run is recorded automatically.
+After \mintinline{bash}{learnlog init python} in the demo project,
+every run during a lecture or tutorial is recorded automatically---no
+code changes to the demonstration scripts are needed.
 After the session, the teacher points the log at a remote
 repository and pushes:
 \begin{minted}{bash}
@@ -39,15 +51,17 @@ learnlog export -o lecture01.bundle
 The teacher distributes the file (\eg via a course page) and
 students replay it directly:
 \begin{minted}{bash}
-learnlog play lecture01.bundle
+learnlog play -f lecture01.bundle
 \end{minted}
 
 \paragraph{Studying how students code.}
 A researcher (or teacher) creates an empty Git repository for each
 student---for instance, one repository per student on a shared
 server.
-Each student adds \mintinline{python}{import learnlog} to their
-programs and configures the remote:
+Each student follows the onboarding page below
+(\mintinline{bash}{pipx install learnlog} followed by
+\mintinline{bash}{learnlog init python} in the project directory) and
+then configures the remote:
 \begin{minted}{bash}
 learnlog set-remote git@gitlab.kth.se:dbosk/alice-log.git
 learnlog push
@@ -72,16 +86,16 @@ learnlog export -o alice-log.bundle
 \end{minted}
 The researcher then replays it directly:
 \begin{minted}{bash}
-learnlog play alice-log.bundle
+learnlog play -f alice-log.bundle
 \end{minted}
 This gives a complete timeline of how students develop and debug
 their code---useful for research purposes or to help students
 refine their debugging techniques.
 
 \paragraph{A student-facing onboarding page.}
-Both use cases above assume students have already installed the
-package, configured a virtual environment, and added
-\mintinline{python}{import learnlog} to their programs.
+Both use cases above assume students have already installed
+[[learnlog]] with \mintinline{bash}{pipx} and run
+\mintinline{bash}{learnlog init python} in the project directory.
 For first-year students this is not routine, so teachers need
 onboarding material.
 Rather than leave each teacher to write their own, we ship a
@@ -129,51 +143,96 @@ This page walks through setup, use, and submission in VS Code.
 - **Visual Studio Code** with the **Python** extension (by
   Microsoft).
 - **Git** on your `PATH` (`git --version`).
-- A project folder for your course work, opened in VS Code.
 
 ## One-time setup
 
 Open the integrated terminal in VS Code (menu **View → Terminal**)
-and run these commands from your project folder.
+and work through the three steps below.
 
-### 1. Create and activate a virtual environment
+### 1. Install pipx
 
-```bash
-python3 -m venv .venv
-# Linux / macOS:
-source .venv/bin/activate
-# Windows (PowerShell):
-.venv\Scripts\Activate.ps1
-```
+`pipx` installs Python command-line tools into their own isolated
+environments and puts them on your `PATH`. Check whether you already
+have it with `pipx --version`; if the command is found, skip to
+step 2.
 
-Make sure VS Code uses this interpreter: open the Command Palette
-(**Ctrl+Shift+P** or **Cmd+Shift+P**), run **Python: Select
-Interpreter**, and pick the one under `.venv`.
+The official installation guide, with platform-specific notes, is at
+<https://pipx.pypa.io/stable/installation/>. Typical commands:
+
+- **Linux (Debian/Ubuntu 23.04+, recent Fedora, Arch, etc.):**
+
+  ```bash
+  sudo apt install pipx    # or: sudo dnf install pipx
+  pipx ensurepath
+  ```
+
+- **macOS (with Homebrew):**
+
+  ```bash
+  brew install pipx
+  pipx ensurepath
+  ```
+
+- **Windows (PowerShell):**
+
+  ```powershell
+  py -m pip install --user pipx
+  py -m pipx ensurepath
+  ```
+
+  If you use Scoop, `scoop install pipx` works too.
+
+- **Fallback (any OS with Python 3.9+):**
+
+  ```bash
+  python3 -m pip install --user pipx
+  python3 -m pipx ensurepath
+  ```
+
+After `pipx ensurepath`, **close and reopen the terminal** so your
+shell picks up the updated `PATH`. If `pipx --version` still fails,
+see <https://pipx.pypa.io/stable/> for troubleshooting.
 
 ### 2. Install learnlog
 
 ```bash
-pip install learnlog
+pipx install learnlog
 ```
 
-### 3. Initialise the log repository
+This puts the `learnlog` command on your `PATH` in its own isolated
+environment, separate from any project. Upgrade later with
+`pipx upgrade learnlog`.
+
+### 3. Set up the project
+
+Open a terminal in your project folder and run:
 
 ```bash
-learnlog init
+learnlog init python
 ```
 
-This creates a hidden `.learnlog/` directory at the top of your
-project. The active virtual environment is remembered, so scripts
-you run later use the correct interpreter automatically.
+This creates a hidden `.learnlog/` directory (the log repository)
+and a project `.venv/` wired so that every Python run through that
+venv is captured automatically. The command prints an activation
+hint when it finishes.
+
+Tell VS Code to use the project venv: open the Command Palette
+(**Ctrl+Shift+P** or **Cmd+Shift+P**), run **Python: Select
+Interpreter**, and pick the one under `.venv`. The integrated
+terminal and the **Run** button will then use the wired interpreter.
+
+Re-running `learnlog init python` later is safe: the command is
+idempotent and will reuse an existing `.venv/` rather than replace
+it.
 
 ## Everyday use
 
 Just run your Python scripts the way you normally would — the VS
 Code **Run** button, `python myscript.py` in the terminal, or
 **F5** for the debugger. You do not need to import or configure
-anything in your own code: `learnlog init` installed an autostart
-hook inside the virtual environment, so every run through the
-`.venv` interpreter is captured automatically.
+anything in your own code: `learnlog init python` installed an
+autostart hook inside the virtual environment, so every run through
+the `.venv` interpreter is captured automatically.
 
 Every run is recorded: source code, command-line arguments,
 stdin/stdout/stderr, and any exception traceback. Even syntax
@@ -184,10 +243,11 @@ script.
 `learnlog` never changes what your program prints or does. If
 logging fails for any reason, your program keeps running.
 
-If you sometimes run scripts with a different Python interpreter
-(outside the venv), add `import learnlog` as the first line of
-the script as an explicit opt-in. This only captures runs where
-`learnlog` is installed in that other interpreter.
+If a particular run will not go through the project `.venv` (for
+example, a grader on a different machine, or a quick script on a
+system without the venv), add `import learnlog` as the first line
+of the script as an explicit opt-in. This only captures runs where
+`learnlog` is installed in the interpreter being used.
 
 ## Review your own session
 
@@ -225,18 +285,22 @@ Upload `mylog.bundle` through the course platform as instructed.
 
 ## Troubleshooting
 
-- **`learnlog: command not found`** — the virtual environment
-  isn't active. Re-run the activation command for your platform,
-  or reopen VS Code's terminal after selecting the interpreter.
+- **`learnlog: command not found`** — `pipx`'s bin directory is
+  not on your `PATH`. Run `pipx ensurepath` and then close and
+  reopen your terminal. Platform-specific `PATH` guidance is at
+  <https://pipx.pypa.io/stable/installation/>.
 - **Nothing appears in `.learnlog/` after running a script** —
   check that VS Code (or your terminal) is actually using the
-  `.venv` interpreter. The autostart hook lives inside the venv,
-  so a script run with a different Python is not captured.
+  project `.venv` interpreter. The autostart hook lives inside
+  the venv, so a script run with a different Python is not
+  captured.
 - **You already had a project Git repository** — the `.learnlog/`
   directory is independent; do **not** `git add .learnlog/` in
   your project's own repository. It manages itself.
-- **Need to start over** — delete `.learnlog/` and run
-  `learnlog init` again; your own code is untouched.
+- **Need to start over** — re-run `learnlog init python`; it is
+  idempotent and reuses an existing `.venv/`. Only if you want
+  to erase your history, delete `.learnlog/` first; your own code
+  is untouched either way.
 @
 
 \section{Code overview}

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -314,6 +314,8 @@ start_time = None
 main_script = None
 main_args = None
 repl_capture_restore = None
+repl_capture_flush = None
+repl_capture_skip_input = None
 @
 
 
@@ -477,7 +479,9 @@ second identical [[stdin:]] entry for the same line.
 def _wrap_input(original_input, iolog):
     """Return an ``input`` wrapper that records returned lines."""
     def logged_input(prompt=""):
+        _flush_pending_repl_capture()
         line = original_input(prompt)
+        _skip_repl_input_history(line)
         if not isinstance(sys.stdin, InputCapture):
             iolog.log("stdin", line + "\n")
         return line
@@ -532,47 +536,169 @@ def _wrap_pyrepl_input(original_input, iolog):
     return logged_input
 @
 
+Older CPython versions still expose one useful clue: once the stock
+REPL has accepted a top-level line, [[readline]] usually appends it to
+history.
+That does not tell us the exact instant the statement became complete,
+so this path is weaker than [[_pyrepl]]: a silent statement may remain
+pending until some later visible effect or until the session exits.
+It is still good enough to flush accepted statements before stdout or
+stderr output, before unhandled exceptions, and before nested
+[[input()]] replies.
+
+<<functions>>=
+def _install_readline_repl_capture(iolog, readline_module):
+    """Return fallback helpers based on readline history."""
+    try:
+        history_length = readline_module.get_current_history_length()
+    except Exception:
+        return None, None
+
+    def flush():
+        nonlocal history_length
+        try:
+            current = readline_module.get_current_history_length()
+        except Exception:
+            return
+        if current <= history_length:
+            return
+        for index in range(history_length + 1, current + 1):
+            try:
+                statement = readline_module.get_history_item(index)
+            except Exception:
+                statement = None
+            if statement is not None:
+                _log_repl_statement(iolog, statement)
+        history_length = current
+
+    def skip_input(line):
+        nonlocal history_length
+        try:
+            current = readline_module.get_current_history_length()
+        except Exception:
+            return
+        if current <= history_length:
+            return
+        new_items = []
+        for index in range(history_length + 1, current + 1):
+            try:
+                statement = readline_module.get_history_item(index)
+            except Exception:
+                statement = None
+            new_items.append(statement)
+        if new_items and new_items[-1] == line:
+            for statement in new_items[:-1]:
+                if statement is not None:
+                    _log_repl_statement(iolog, statement)
+            history_length = current
+            return
+        flush()
+
+    return flush, skip_input
+@
+
+We trigger those deferred flushes from the places where Python does hand
+control back to us: output writes, nested [[input()]] calls, unhandled
+exceptions, and exit cleanup.
+
+<<functions>>=
+def _flush_pending_repl_capture():
+    """Flush any deferred REPL capture state."""
+    if repl_capture_flush is None:
+        return
+    try:
+        repl_capture_flush()
+    except Exception:
+        pass
+
+
+def _skip_repl_input_history(line):
+    """Ignore a nested REPL ``input()`` reply already logged elsewhere."""
+    if repl_capture_skip_input is None:
+        return
+    try:
+        repl_capture_skip_input(line)
+    except Exception:
+        pass
+@
+
+Output is the most important synchronization point.
+If a fallback REPL statement such as [[print(value)]] produces text, the
+statement should reach the log before the resulting stdout or stderr
+entry.
+We therefore use a tiny output wrapper that flushes any deferred REPL
+history first.
+Outside REPL mode that hook is inert.
+
+<<functions>>=
+class ReplAwareStreamCapture(StreamCapture):
+    """StreamCapture that flushes deferred REPL input first."""
+
+    def write(self, text):
+        _flush_pending_repl_capture()
+        return super().write(text)
+@
+
 When [[_pyrepl]] is unavailable, or if its internal interface changes,
-we do nothing special here.
+we fall back to the weaker [[readline]] path.
+If neither mechanism is present, we do nothing special here.
 The ordinary [[builtins.input]] wrapper still covers interactive
 [[input()]] calls, including [[input()]] executed from REPL code.
 Pyrepl-equipped interpreters get the stronger guarantee of both inline
-top-level statement logging and REPL-time [[input()]] capture from the
-hooks below.
+top-level statement logging and REPL-time [[input()]] capture; older
+readline-based interpreters get best-effort top-level statement capture
+at those later synchronization points.
 
 <<functions>>=
 def _install_repl_capture(
-    script, iolog, pyrepl_readline=None, simple_interact=None,
+    script,
+    iolog,
+    pyrepl_readline=None,
+    simple_interact=None,
+    readline_module=None,
 ):
-    """Install inline REPL capture hooks and return a restore callback."""
+    """Install REPL capture and return restore/flush helpers."""
     if script != "<repl>":
-        return None
+        return None, None, None
     if pyrepl_readline is None or simple_interact is None:
         try:
             import _pyrepl.readline as pyrepl_readline
             import _pyrepl.simple_interact as simple_interact
         except Exception:
-            return None
+            pyrepl_readline = None
+            simple_interact = None
 
-    original_multiline_input = simple_interact.multiline_input
-    wrapper_type = type(pyrepl_readline._wrapper)
-    original_pyrepl_input = wrapper_type.input
+    if pyrepl_readline is not None and simple_interact is not None:
+        original_multiline_input = simple_interact.multiline_input
+        wrapper_type = type(pyrepl_readline._wrapper)
+        original_pyrepl_input = wrapper_type.input
 
-    def logged_multiline_input(more_lines, ps1, ps2):
-        statement = original_multiline_input(more_lines, ps1, ps2)
-        _log_repl_statement(iolog, statement)
-        return statement
+        def logged_multiline_input(more_lines, ps1, ps2):
+            statement = original_multiline_input(more_lines, ps1, ps2)
+            _log_repl_statement(iolog, statement)
+            return statement
 
-    simple_interact.multiline_input = logged_multiline_input
-    wrapper_type.input = _wrap_pyrepl_input(
-        original_pyrepl_input, iolog,
+        simple_interact.multiline_input = logged_multiline_input
+        wrapper_type.input = _wrap_pyrepl_input(
+            original_pyrepl_input, iolog,
+        )
+
+        def restore():
+            simple_interact.multiline_input = original_multiline_input
+            wrapper_type.input = original_pyrepl_input
+
+        return restore, None, None
+
+    if readline_module is None:
+        try:
+            import readline as readline_module
+        except Exception:
+            return None, None, None
+
+    flush, skip_input = _install_readline_repl_capture(
+        iolog, readline_module,
     )
-
-    def restore():
-        simple_interact.multiline_input = original_multiline_input
-        wrapper_type.input = original_pyrepl_input
-
-    return restore
+    return None, flush, skip_input
 @
 
 <<functions>>=
@@ -585,6 +711,7 @@ def initialize():
     global repo, iolog, start_time, main_script, main_args
     global original_stdout, original_stderr, original_stdin
     global original_input, repl_capture_restore
+    global repl_capture_flush, repl_capture_skip_input
 
     if repo is not None:
         return
@@ -629,15 +756,19 @@ original_stdout = sys.stdout
 original_stderr = sys.stderr
 original_stdin = sys.stdin
 original_input = builtins.input
-sys.stdout = StreamCapture(original_stdout, "stdout", iolog)
-sys.stderr = StreamCapture(original_stderr, "stderr", iolog)
+sys.stdout = ReplAwareStreamCapture(original_stdout, "stdout", iolog)
+sys.stderr = ReplAwareStreamCapture(original_stderr, "stderr", iolog)
 if not original_stdin.isatty():
     sys.stdin = InputCapture(original_stdin, iolog)
 builtins.input = _wrap_input(original_input, iolog)
 @
 
 <<install REPL capture>>=
-repl_capture_restore = _install_repl_capture(main_script, iolog)
+(
+    repl_capture_restore,
+    repl_capture_flush,
+    repl_capture_skip_input,
+) = _install_repl_capture(main_script, iolog)
 @
 
 Let's verify that initialisation creates the repository and wraps
@@ -831,6 +962,9 @@ Let's verify the helper pieces directly.
 The [[input()]] wrapper must add a line only when stdin is not already
 an [[InputCapture]], and the REPL helpers must format and install
 inline capture correctly.
+The older [[readline]] fallback is weaker, but it still needs to log
+accepted statements, keep nested [[input()]] replies from being doubled,
+and flush pending statements before visible output.
 
 <<test functions>>=
 def test_wrap_input_logs_when_stdin_is_not_wrapped(monkeypatch):
@@ -892,7 +1026,7 @@ def test_install_repl_capture_logs_inline_repl_events():
     simple_interact.multiline_input = lambda more_lines, ps1, ps2: "2+2"
 
     log = learnlog.IOLog()
-    restore = learnlog._install_repl_capture(
+    restore, flush, skip_input = learnlog._install_repl_capture(
         "<repl>",
         log,
         pyrepl_readline=FakePyreplReadline,
@@ -900,6 +1034,8 @@ def test_install_repl_capture_logs_inline_repl_events():
     )
 
     assert restore is not None
+    assert flush is None
+    assert skip_input is None
     assert simple_interact.multiline_input(None, ">>> ", "... ") == "2+2"
     assert FakePyreplReadline._wrapper.input("prompt") == "typed"
 
@@ -911,6 +1047,116 @@ def test_install_repl_capture_logs_inline_repl_events():
         "stdin: >>> 2+2\n"
         "stdin: typed\n"
     )
+
+
+def test_install_repl_capture_returns_no_hooks_without_support(
+    monkeypatch,
+):
+    import builtins
+    import learnlog
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("_pyrepl") or name == "readline":
+            raise ImportError(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    log = learnlog.IOLog()
+    assert learnlog._install_repl_capture(
+        "<repl>",
+        log,
+        pyrepl_readline=None,
+        simple_interact=None,
+        readline_module=None,
+    ) == (None, None, None)
+
+
+def test_install_readline_repl_capture_logs_history_entries():
+    import learnlog
+
+    class FakeReadline:
+        history = ["old"]
+
+        @classmethod
+        def get_current_history_length(cls):
+            return len(cls.history)
+
+        @classmethod
+        def get_history_item(cls, index):
+            return cls.history[index - 1]
+
+    log = learnlog.IOLog()
+    flush, skip_input = learnlog._install_readline_repl_capture(
+        log, FakeReadline,
+    )
+
+    assert flush is not None
+    assert skip_input is not None
+
+    FakeReadline.history.extend([
+        "2+2",
+        "for i in range(2):\n    print(i)",
+    ])
+    flush()
+
+    assert log.getvalue() == (
+        "stdin: >>> 2+2\n"
+        "stdin: >>> for i in range(2):\n"
+        "stdin: ...     print(i)\n"
+    )
+
+
+def test_readline_repl_capture_skips_nested_input_history():
+    import learnlog
+
+    class FakeReadline:
+        history = []
+
+        @classmethod
+        def get_current_history_length(cls):
+            return len(cls.history)
+
+        @classmethod
+        def get_history_item(cls, index):
+            return cls.history[index - 1]
+
+    log = learnlog.IOLog()
+    flush, skip_input = learnlog._install_readline_repl_capture(
+        log, FakeReadline,
+    )
+
+    FakeReadline.history.extend(["value = input()", "typed"])
+    skip_input("typed")
+
+    assert log.getvalue() == "stdin: >>> value = input()\n"
+    flush()
+    assert log.getvalue() == "stdin: >>> value = input()\n"
+
+
+def test_repl_aware_stream_capture_flushes_pending_repl_history(
+    monkeypatch,
+):
+    import learnlog
+
+    flushed = []
+    monkeypatch.setattr(
+        learnlog,
+        "repl_capture_flush",
+        lambda: flushed.append("flushed"),
+    )
+
+    original = io.StringIO()
+    log = learnlog.IOLog()
+    capture = learnlog.ReplAwareStreamCapture(original, "stdout", log)
+
+    capture.write("hello\n")
+
+    assert flushed == ["flushed"]
+    assert original.getvalue() == "hello\n"
+    assert log.getvalue() == "stdout: hello\n"
 @
 
 
@@ -932,6 +1178,7 @@ original_excepthook = sys.excepthook
 
 def exception_hook(exc_type, exc_value, exc_tb):
     global exception_info
+    _flush_pending_repl_capture()
     exception_info = "".join(
         traceback.format_exception(
             exc_type, exc_value, exc_tb
@@ -993,6 +1240,7 @@ def on_exit():
     global repo, iolog, exception_info
     global original_stdout, original_stderr, original_stdin
     global original_input, repl_capture_restore
+    global repl_capture_flush, repl_capture_skip_input
 
     if repo is None:
         return
@@ -1017,8 +1265,12 @@ if original_input is not None:
 @
 
 <<restore REPL capture>>=
+_flush_pending_repl_capture()
 if repl_capture_restore is not None:
     repl_capture_restore()
+repl_capture_restore = None
+repl_capture_flush = None
+repl_capture_skip_input = None
 @
 
 <<finalise the run>>=

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -124,7 +124,7 @@ This page walks through setup, use, and submission in VS Code.
 
 ## What you need
 
-- **Python 3.10 or newer.** Check with `python3 --version` in a
+- **Python 3.9 or newer.** Check with `python3 --version` in a
   terminal.
 - **Visual Studio Code** with the **Python** extension (by
   Microsoft).
@@ -168,23 +168,26 @@ you run later use the correct interpreter automatically.
 
 ## Everyday use
 
-Add a single line as the **first line** of each Python file you
-want logged:
+Just run your Python scripts the way you normally would — the VS
+Code **Run** button, `python myscript.py` in the terminal, or
+**F5** for the debugger. You do not need to import or configure
+anything in your own code: `learnlog init` installed an autostart
+hook inside the virtual environment, so every run through the
+`.venv` interpreter is captured automatically.
 
-```python
-import learnlog
-```
-
-Run the script however you normally do — the VS Code **Run**
-button, `python myscript.py` in the terminal, or **F5** for the
-debugger. Every run is recorded: source code, command-line
-arguments, stdin/stdout/stderr, and any exception traceback.
-Even syntax errors that stop the script before it starts are
-recorded, because `learnlog init` installed an autostart hook
-inside the virtual environment.
+Every run is recorded: source code, command-line arguments,
+stdin/stdout/stderr, and any exception traceback. Even syntax
+errors that stop the script before it starts are recorded,
+because the autostart hook runs before Python compiles your
+script.
 
 `learnlog` never changes what your program prints or does. If
 logging fails for any reason, your program keeps running.
+
+If you sometimes run scripts with a different Python interpreter
+(outside the venv), add `import learnlog` as the first line of
+the script as an explicit opt-in. This only captures runs where
+`learnlog` is installed in that other interpreter.
 
 ## Review your own session
 
@@ -226,8 +229,9 @@ Upload `mylog.bundle` through the course platform as instructed.
   isn't active. Re-run the activation command for your platform,
   or reopen VS Code's terminal after selecting the interpreter.
 - **Nothing appears in `.learnlog/` after running a script** —
-  make sure `import learnlog` is the first non-comment line of the
-  script you're actually running.
+  check that VS Code (or your terminal) is actually using the
+  `.venv` interpreter. The autostart hook lives inside the venv,
+  so a script run with a different Python is not captured.
 - **You already had a project Git repository** — the `.learnlog/`
   directory is independent; do **not** `git add .learnlog/` in
   your project's own repository. It manages itself.
@@ -1426,7 +1430,7 @@ initialize()
 
 
 \section{Auto-starting without explicit import}
-\label{autostart}
+\label{sec:autostart}
 
 The mechanism described so far captures everything \emph{after} the
 interpreter reaches \mintinline{python}{import learnlog}.
@@ -1458,7 +1462,7 @@ The [[_autostart]] module is a \emph{gate}: it decides whether
 \emph{this} interpreter invocation should be logged and, if so,
 its explicit [[autostart()]] entry point imports [[learnlog]], reusing the ordinary
 \mintinline{python}{import learnlog} machinery
-(\cref{autostart on import}).
+(\cref{sec:autostart-on-import}).
 Rather than duplicate the repository-discovery path, the gate
 communicates the project root to [[initialize]] by setting
 [[LEARNLOG_PROJECT_ROOT]] in the environment.
@@ -1542,7 +1546,7 @@ still points at the old location.
 
 The \textbf{backup source} is [[Path(sys.prefix).parent]].
 With the conventional [[<project>/.venv/]] layout (produced by
-both [[learnlog init]] and VS Code's ``Create Environment''),
+both [[learnlog init]] and VS Code's \enquote{Create Environment}),
 this resolves to the project root even after the project is
 renamed or moved---because the venv moves with it.
 But the layout is a convention, not a guarantee: a venv at
@@ -1609,7 +1613,7 @@ deleted projects.
 def _read_marker(marker_path):
     """Return the path stored in ``marker_path`` if still valid.
 
-    ``Valid'' means the file exists, is readable, and points at a
+    "Valid" means the file exists, is readable, and points at a
     directory that still contains a ``.learnlog/`` subdirectory.
     Returns ``None`` otherwise.
     """
@@ -1759,7 +1763,7 @@ def _should_activate(
 
 
 \subsection{Startup entry point}
-\label{autostart on import}
+\label{sec:autostart-on-import}
 
 The last piece runs at interpreter startup---once, when the
 [[.pth]] line calls [[autostart()]].
@@ -1859,7 +1863,7 @@ from learnlog._autostart import _should_activate
 @
 
 A valid project has a [[.learnlog/]] directory; a valid marker
-holds the path to such a project; a ``no-backup'' [[sys.prefix]]
+holds the path to such a project; a \enquote{no-backup} [[sys.prefix]]
 points somewhere far from any [[.learnlog/]], so tests of the
 marker path are not secretly passing via the backup.
 

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -97,7 +97,7 @@ eval "$(learnlog activate)"
 \end{minted}
 before starting the session.
 
-To publish the recoded sessions, we can simply push the hidden Git repository 
+To publish the recorded sessions, we can simply push the hidden Git repository
 to a shared remote.
 After the session, the teacher points the log at a remote
 repository and pushes:
@@ -204,7 +204,7 @@ This gives a complete timeline of how students develop and debug
 their code---useful for research purposes or to help students
 refine their debugging techniques.
 
-\subsection{A student-facing onboarding page.}
+\subsection{A student-facing onboarding page}
 
 Both use cases above assume students have already installed
 [[learnlog]] with \mintinline{bash}{pipx} and run
@@ -226,6 +226,16 @@ command:
 canvaslms pages edit --create -c COURSE \
   -f src/learnlog/students.md
 \end{minted}
+[[students.md]] is a tangled artefact excluded from the published
+wheel, so a teacher who installed via [[pipx install learnlog]]
+does not have this file on disk.  Publishing the page therefore
+requires a source checkout---\mintinline{bash}{git clone} the
+[[learnlog]] repository and run \mintinline{bash}{make} to tangle
+[[students.md]] from this chapter.  If course staff need a
+packaged route later, a [[learnlog canvaslms-onboarding]]
+subcommand that writes the file to a chosen path would be the
+natural next step.
+
 We deliberately omit course-specific metadata---Canvas module
 assignment and stable-identification regex---because one tangled
 file must work unchanged across every course using learnlog.
@@ -1662,7 +1672,7 @@ Rather than duplicate the repository-discovery path, the gate
 communicates the project root to [[initialize]] by setting
 [[LEARNLOG_PROJECT_ROOT]] in the environment.
 
-\paragraph{Why \texttt{.pth} rather than \texttt{sitecustomize.py}.}
+\paragraph{Why [[.pth]] rather than [[sitecustomize.py]].}
 The venv may already carry a [[sitecustomize.py]] written by
 another tool (Python loads only one).
 Multiple [[.pth]] files coexist, so we cannot collide.
@@ -1905,16 +1915,15 @@ def _resolve_project_root(marker_path=None, sys_prefix=None):
 logged: it is creating the repository, so it has no repository
 to commit into yet (or, on re-init, it is changing the repository
 from under itself).
-Every \emph{other} [[learnlog]] subcommand---[[play]], [[export]],
-[[tag]], [[list]], [[analyse]]---is research-valuable data about
-how the student interacts with their own log and must be captured
-like any other program.
+Every \emph{other} [[learnlog]] subcommand is research-valuable
+data about how the student interacts with their own log and must
+be captured like any other program.
 
 We detect [[learnlog init]] by matching [[argv[0]]] against the
 script name and [[argv[1]]] against the literal [[init]].
 [[argv[0]]] can be either the [[learnlog]] entry-point script
 itself (installed in [[<venv>/bin/]]) or a path to the package's
-[[\_\_main\_\_.py]] when invoked as [[python -m learnlog]];
+[[__main__.py]] when invoked as [[python -m learnlog]];
 both contain [[learnlog]] as a path component.
 
 <<autostart gate helpers>>=
@@ -1969,8 +1978,8 @@ unit tests must be able to import [[learnlog._autostart]] to reach
 environment.
 
 If the gate returns a project root, we stash it in
-[[LEARNLOG_PROJECT_ROOT]] so [[initialize]] will find the right
-[[.learnlog/]] (see task~\#4), then [[import learnlog]] to
+[[LEARNLOG_PROJECT_ROOT]] so [[initialize]] (\cref{learnlog})
+will find the right [[.learnlog/]], then [[import learnlog]] to
 trigger the ordinary import-time initialisation path.
 If the gate returns [[None]], we silently do nothing and the
 interpreter continues as if we were not installed.
@@ -2004,7 +2013,7 @@ The fixtures below build a minimal filesystem fixture and then
 drive [[_should_activate]] with explicit overrides---no subprocess,
 no real venv, no patching of [[sys]].
 End-to-end verification that the [[.pth]] hook is actually picked
-up by CPython lives in task~\#6's integration tests.
+up by CPython lives in \cref{subsec:end-to-end-autostart-tests}.
 
 Importing the module itself must stay side-effect free.
 The actual startup action now lives in [[autostart()]], because test
@@ -2271,6 +2280,7 @@ backup different valid projects; the marker's project is what
 
 
 \subsection{End-to-end autostart tests}
+\label{subsec:end-to-end-autostart-tests}
 
 The gate tests above prove the decision logic in isolation.
 They do not prove that CPython actually executes the [[.pth]] hook

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -488,12 +488,16 @@ def _wrap_input(original_input, iolog):
 REPL statements need a second supplement.
 Top-level lines such as [[2+2]] or [[raise RuntimeError('x')]] do not
 flow through [[input()]] at all.
-On current Python versions the interactive frontend asks
+On current CPython versions that ship the stdlib [[_pyrepl]] frontend
+(3.13+ at the time of writing), the interactive frontend asks
 [[_pyrepl.simple_interact.multiline_input]] for each completed
 statement, then executes it.
 By wrapping that function we can log the entered statement at the
 moment it becomes complete, which preserves the same chronological
 ordering as the live REPL without scraping terminal repaint bytes.
+This is a best-effort compatibility path rather than a universal REPL
+API: older CPython versions and non-CPython interpreters may not ship
+[[_pyrepl]] at all.
 
 <<functions>>=
 def _log_repl_statement(iolog, statement):
@@ -513,6 +517,9 @@ reader.
 That would bypass our ordinary [[_wrap_input]] logging for
 [[input()]] calls made from inside the REPL, so we wrap pyrepl's input
 method as well.
+Without that second hook we would capture [[value = input()]] as a
+statement, but miss the student's reply that the running code reads from
+the terminal.
 
 <<functions>>=
 def _wrap_pyrepl_input(original_input, iolog):
@@ -525,10 +532,13 @@ def _wrap_pyrepl_input(original_input, iolog):
     return logged_input
 @
 
-When [[_pyrepl]] is unavailable we do nothing special here.
-The ordinary [[builtins.input]] wrapper still covers the basic REPL,
-while pyrepl-equipped interpreters get inline statement logging and
-interactive [[input()]] capture from the hooks below.
+When [[_pyrepl]] is unavailable, or if its internal interface changes,
+we do nothing special here.
+The ordinary [[builtins.input]] wrapper still covers interactive
+[[input()]] calls, including [[input()]] executed from REPL code.
+Pyrepl-equipped interpreters get the stronger guarantee of both inline
+top-level statement logging and REPL-time [[input()]] capture from the
+hooks below.
 
 <<functions>>=
 def _install_repl_capture(
@@ -2115,9 +2125,46 @@ def test_autostart_captures_named_entry_points(tmp_path):
 @
 
 The REPL path is the remaining truly interactive case.
-CPython reads top-level statements through [[readline]] on the TTY,
-not through [[sys.stdin]], so the only way to verify the inline
-[[pyrepl]] hook is to drive a real REPL over a pseudoterminal.
+On the CPython 3.13+ builds we target today, top-level statements flow
+through [[pyrepl]] on the TTY, not through [[sys.stdin]], so the only
+way to verify the inline hook is to drive a real REPL over a
+pseudoterminal.
+The first smoke test covers the success path where a REPL statement
+calls [[input()]]: we must see both the entered statement and the
+student's reply in the log, in that order.
+Older interpreters fall back safely, but they do not exercise this
+stronger inline-statement path.
+
+<<autostart test functions>>=
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="pty is unavailable on Windows"
+)
+def test_autostart_captures_repl_input_calls(tmp_path):
+    project, venv_dir = _prepare_autostart_project(tmp_path)
+    returncode, _ = _run_in_pty(
+        [str(_venv_binary(venv_dir, "python"))],
+        cwd=project,
+        env=_autostart_env(),
+        input_text=(
+            "value = input()\n"
+            "hello from repl\n"
+            "print(value)\n"
+            "exit()\n"
+        ),
+    )
+
+    assert returncode == 0
+
+    history = _git_history(project)
+    assert "Script: <repl>" in history
+    assert "stdin: >>> value = input()\n" in history
+    assert "stdin: hello from repl\n" in history
+    assert "stdin: >>> print(value)\n" in history
+    assert "stdout: hello from repl\n" in history
+    assert "stdin: >>> exit()\n" in history
+@
+
+A second REPL smoke test keeps the exception path covered.
 
 <<autostart test functions>>=
 @pytest.mark.skipif(

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -16,20 +16,34 @@ Installation is rather simple:
 pipx install learnlog
 \end{minted}
 This one-time line puts the tool on the [[PATH]].
-In VSCode and Repl.it that have a built-in virtual environment automatically, 
-one can go for the per-project installation instead, with
-\mintinline{bash}{pip install learnlog} (no x in pip)
-in the project venv.
+In VSCode and Repl.it that manage a project virtual environment
+automatically, one can go for the per-project installation
+instead, with \mintinline{bash}{pip install learnlog}
+(no x in pip) in the project venv.
 
-Then we can use the [[learnlog]] tool to activate it in any project:
+Then we can use the [[learnlog]] tool to set up logging in
+any project:
 \begin{minted}{bash}
 cd the-project-directory
 learnlog init python
 \end{minted}
-Running \mintinline{bash}{learnlog init python} in a project directory creates 
-a hidden Git repository alongside a virtual environment wired
-so that every subsequent Python run through that venv is captured
-automatically.
+Running \mintinline{bash}{learnlog init python} in a
+project directory creates the hidden Git repository for the
+log. If a virtual environment is already active---as is
+often the case in VSCode's integrated terminal---[[init]]
+installs and wires [[learnlog]] into that active venv.
+Otherwise [[init]] reuses or creates a project [[.venv/]]
+and wires that one instead. In a plain shell where that
+venv is not active, enter it with
+\begin{minted}{bash}
+eval "$(learnlog activate)"
+\end{minted}
+and leave it again with
+\begin{minted}{bash}
+eval "$(learnlog deactivate)"
+\end{minted}
+Every subsequent Python run through the wired venv is
+captured automatically.
 When a script runs, an autostart hook triggers a chain of actions: it
 detects which script is running, stages any source code changes into
 the hidden Git repository, wraps the standard streams to capture all
@@ -75,8 +89,13 @@ learnlog init python
 After \mintinline{bash}{learnlog init python} in the demo project,
 every run during a lecture or tutorial is recorded automatically---no
 code changes to the demonstration scripts are needed.
-However, this requires that the Python venv (virtual environment) is activated!
-Tools like VSCode automatically activates the venv.
+In VSCode, the integrated terminal usually already has the
+project [[.venv/]] active, so there is nothing more to do.
+In a plain shell, if the project venv is not active, run
+\begin{minted}{bash}
+eval "$(learnlog activate)"
+\end{minted}
+before starting the session.
 
 To publish the recoded sessions, we can simply push the hidden Git repository 
 to a shared remote.
@@ -292,15 +311,31 @@ Open a terminal in your project folder and run:
 learnlog init python
 ```
 
-This creates a hidden `.learnlog/` directory (the log repository)
-and a project `.venv/` wired so that every Python run through that
-venv is captured automatically. The command prints an activation
-hint when it finishes.
+This creates a hidden `.learnlog/` directory (the log repository).
+If your terminal already has a virtual environment active,
+`learnlog init python` installs and wires `learnlog` into that
+venv. In VS Code's integrated terminal, that is often the
+workspace `.venv/`, so no extra activation step is needed.
 
-Tell VS Code to use the project venv: open the Command Palette
-(**Ctrl+Shift+P** or **Cmd+Shift+P**), run **Python: Select
-Interpreter**, and pick the one under `.venv`. The integrated
-terminal and the **Run** button will then use the wired interpreter.
+If no venv is active, `learnlog init python` reuses or creates
+the project `.venv/` and wires that one instead. If your shell
+does not activate it automatically, enter it with:
+
+```bash
+eval "$(learnlog activate)"
+```
+
+When you are done in that same shell, leave it with:
+
+```bash
+eval "$(learnlog deactivate)"
+```
+
+If VS Code did not already pick the project venv, open the
+Command Palette (**Ctrl+Shift+P** or **Cmd+Shift+P**), run
+**Python: Select Interpreter**, and pick the one under `.venv`.
+The integrated terminal and the **Run** button will then use the
+wired interpreter.
 
 Re-running `learnlog init python` later is safe: the command is
 idempotent and will reuse an existing `.venv/` rather than replace
@@ -372,9 +407,11 @@ Upload `mylog.bundle` through the course platform as instructed.
   <https://pipx.pypa.io/stable/installation/>.
 - **Nothing appears in `.learnlog/` after running a script** —
   check that VS Code (or your terminal) is actually using the
-  project `.venv` interpreter. The autostart hook lives inside
-  the venv, so a script run with a different Python is not
-  captured.
+  venv that `learnlog init python` wired. In VS Code, that is
+  often the workspace `.venv/`; in a plain shell, run
+  `eval "$(learnlog activate)"` if the project venv is not
+  already active. The autostart hook lives inside that venv,
+  so a script run with a different Python is not captured.
 - **You already had a project Git repository** — the `.learnlog/`
   directory is independent; do **not** `git add .learnlog/` in
   your project's own repository. It manages itself.

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -179,6 +179,9 @@ Run the script however you normally do — the VS Code **Run**
 button, `python myscript.py` in the terminal, or **F5** for the
 debugger. Every run is recorded: source code, command-line
 arguments, stdin/stdout/stderr, and any exception traceback.
+Even syntax errors that stop the script before it starts are
+recorded, because `learnlog init` installed an autostart hook
+inside the virtual environment.
 
 `learnlog` never changes what your program prints or does. If
 logging fails for any reason, your program keeps running.
@@ -256,6 +259,7 @@ stored in a hidden ``.learnlog/`` Git repository.
 
 import sys
 import os
+import builtins
 import pathlib
 import datetime
 import atexit
@@ -275,6 +279,7 @@ verifying the full pipeline from import to commit:
 
 <<test [[learnlog.py]]>>=
 """Integration tests for the learnlog package."""
+import io
 import tempfile
 import subprocess
 import os
@@ -303,10 +308,12 @@ iolog = None
 original_stdout = None
 original_stderr = None
 original_stdin = None
+original_input = None
 exception_info = None
 start_time = None
 main_script = None
 main_args = None
+repl_capture_restore = None
 @
 
 
@@ -384,6 +391,151 @@ The entire function is wrapped in a [[try]]/[[except]] that catches
 If learnlog fails for any reason---no Git installed, permission denied,
 disk full---the student's program must still work.
 
+Autostart widens the set of invocations that reach [[initialize]].
+Besides ordinary [[script.py]] runs we now see the bare REPL,
+[[python -c]], [[python -m]], and entry-point scripts such as
+[[pip]] or [[pytest]].
+Those forms need two normalisations before we write a run header:
+which repository to anchor to, and what human-readable name to give
+the invocation.
+
+The repository lookup now prefers [[LEARNLOG_PROJECT_ROOT]] when the
+autostart gate has already resolved the project root from the venv.
+That is what lets a script launched from [[/tmp]] still log into the
+course project's [[.learnlog/]].
+Without it, the fallback [[find_learnlog_dir() or os.getcwd()]] logic
+would anchor such runs to the caller's working directory instead.
+
+The invocation name is normalised rather than copied from
+[[sys.argv[0]]] verbatim.
+Raw values such as the empty string or [[-c]] are faithful to CPython,
+but poor commit headers for humans.
+We map those sentinel forms to labels that explain how Python was
+started while leaving ordinary filenames and entry-point basenames
+unchanged.
+
+<<functions>>=
+def _normalize_main_invocation(argv):
+    """Return a normalised ``(script, args)`` pair from ``argv``."""
+    argv = list(argv) if argv else [""]
+    script = argv[0]
+    special = {
+        "": ("<repl>", lambda values: []),
+        "-c": (
+            "<python -c>",
+            lambda values: [values[1]] if len(values) > 1 else [],
+        ),
+        "-m": ("<python -m>", lambda values: values[1:]),
+    }
+    if script in special:
+        name, args_factory = special[script]
+        return name, args_factory(argv)
+    basename = os.path.basename(script)
+    if script.endswith(".py"):
+        return basename, argv[1:]
+    return basename, argv[1:]
+@
+
+[[InputCapture]] handles piped stdin because [[input()]] eventually
+reads from [[sys.stdin.readline()]].
+That is not enough for interactive terminals, where the REPL and line
+editing stack bypass our wrapper at the C level.
+We therefore also wrap [[builtins.input]], but only as a supplement:
+when [[sys.stdin]] is already an [[InputCapture]] we must not write a
+second identical [[stdin:]] entry for the same line.
+
+<<functions>>=
+def _wrap_input(original_input, iolog):
+    """Return an ``input`` wrapper that records returned lines."""
+    def logged_input(prompt=""):
+        line = original_input(prompt)
+        if not isinstance(sys.stdin, InputCapture):
+            iolog.log("stdin", line + "\n")
+        return line
+
+    return logged_input
+@
+
+REPL statements need a second supplement.
+Top-level lines such as [[2+2]] or [[raise RuntimeError('x')]] do not
+flow through [[input()]] at all.
+On current Python versions the interactive frontend asks
+[[_pyrepl.simple_interact.multiline_input]] for each completed
+statement, then executes it.
+By wrapping that function we can log the entered statement at the
+moment it becomes complete, which preserves the same chronological
+ordering as the live REPL without scraping terminal repaint bytes.
+
+<<functions>>=
+def _log_repl_statement(iolog, statement):
+    """Append one completed REPL statement to ``iolog``."""
+    if not statement:
+        return
+    for index, line in enumerate(statement.splitlines(keepends=True)):
+        prompt = ">>> " if index == 0 else "... "
+        if line.endswith("\n"):
+            iolog.log("stdin", prompt + line)
+        else:
+            iolog.log("stdin", prompt + line + "\n")
+@
+
+The same frontend also replaces [[builtins.input]] with its own TTY
+reader.
+That would bypass our ordinary [[_wrap_input]] logging for
+[[input()]] calls made from inside the REPL, so we wrap pyrepl's input
+method as well.
+
+<<functions>>=
+def _wrap_pyrepl_input(original_input, iolog):
+    """Return a pyrepl ``input`` wrapper that records returned lines."""
+    def logged_input(self, prompt=""):
+        line = original_input(self, prompt)
+        iolog.log("stdin", line + "\n")
+        return line
+
+    return logged_input
+@
+
+When [[_pyrepl]] is unavailable we do nothing special here.
+The ordinary [[builtins.input]] wrapper still covers the basic REPL,
+while pyrepl-equipped interpreters get inline statement logging and
+interactive [[input()]] capture from the hooks below.
+
+<<functions>>=
+def _install_repl_capture(
+    script, iolog, pyrepl_readline=None, simple_interact=None,
+):
+    """Install inline REPL capture hooks and return a restore callback."""
+    if script != "<repl>":
+        return None
+    if pyrepl_readline is None or simple_interact is None:
+        try:
+            import _pyrepl.readline as pyrepl_readline
+            import _pyrepl.simple_interact as simple_interact
+        except Exception:
+            return None
+
+    original_multiline_input = simple_interact.multiline_input
+    wrapper_type = type(pyrepl_readline._wrapper)
+    original_pyrepl_input = wrapper_type.input
+
+    def logged_multiline_input(more_lines, ps1, ps2):
+        statement = original_multiline_input(more_lines, ps1, ps2)
+        _log_repl_statement(iolog, statement)
+        return statement
+
+    simple_interact.multiline_input = logged_multiline_input
+    wrapper_type.input = _wrap_pyrepl_input(
+        original_pyrepl_input, iolog,
+    )
+
+    def restore():
+        simple_interact.multiline_input = original_multiline_input
+        wrapper_type.input = original_pyrepl_input
+
+    return restore
+@
+
 <<functions>>=
 def initialize():
     """Set up learnlog: detect script, init repo, wrap streams.
@@ -393,15 +545,16 @@ def initialize():
     """
     global repo, iolog, start_time, main_script, main_args
     global original_stdout, original_stderr, original_stdin
+    global original_input, repl_capture_restore
 
     if repo is not None:
         return
 
     try:
         <<detect main script>>
-        <<skip if running as CLI tool>>
         <<create repository and begin run>>
         <<install I/O wrappers>>
+        <<install REPL capture>>
         <<install exception hook>>
         atexit.register(on_exit)
     except Exception:
@@ -409,26 +562,14 @@ def initialize():
 @
 
 <<detect main script>>=
-main_script = os.path.basename(sys.argv[0])
-main_args = sys.argv[1:]
+main_script, main_args = _normalize_main_invocation(sys.argv)
 start_time = datetime.datetime.now()
-workdir = find_learnlog_dir() or os.getcwd()
-@
-
-When [[learnlog]] is invoked as a CLI tool (\eg [[learnlog play]] or
-[[learnlog export]]), we must not run initialisation.
-Without this guard, running [[learnlog play]] from the home directory
-would create a [[.learnlog/]] repository there---staging every file
-in [[\$HOME]] into Git.
-Even in a project directory, the CLI's own invocations would clutter
-the student's development log with tool usage rather than program runs.
-The entry point in [[pyproject.toml]] is [[learnlog.cli:app]], so
-[[sys.argv[0]]] resolves to the [[learnlog]] script.
-We detect this and skip initialisation entirely.
-
-<<skip if running as CLI tool>>=
-if main_script == "learnlog":
-    return
+project_root = os.environ.get("LEARNLOG_PROJECT_ROOT")
+workdir = (
+    pathlib.Path(project_root)
+    if project_root is not None
+    else find_learnlog_dir() or os.getcwd()
+)
 @
 
 If [[find_learnlog_dir]] finds no existing repository, the fallback to
@@ -446,9 +587,16 @@ iolog = IOLog()
 original_stdout = sys.stdout
 original_stderr = sys.stderr
 original_stdin = sys.stdin
+original_input = builtins.input
 sys.stdout = StreamCapture(original_stdout, "stdout", iolog)
 sys.stderr = StreamCapture(original_stderr, "stderr", iolog)
-sys.stdin = InputCapture(original_stdin, iolog)
+if not original_stdin.isatty():
+    sys.stdin = InputCapture(original_stdin, iolog)
+builtins.input = _wrap_input(original_input, iolog)
+@
+
+<<install REPL capture>>=
+repl_capture_restore = _install_repl_capture(main_script, iolog)
 @
 
 Let's verify that initialisation creates the repository and wraps
@@ -498,14 +646,48 @@ class TestInitialize:
         )
         assert "visible" in result.stdout
 
-    def test_skips_when_running_as_cli(self, workdir, test_env):
-        """Simulates sys.argv[0] being 'learnlog'."""
-        script = workdir / "test_cli_skip.py"
+    def test_honours_project_root_env_var(self, test_env, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        subdir = project_root / "subdir"
+        subdir.mkdir()
+        script = subdir / "test_env_root.py"
+        script.write_text(
+            "import os\n"
+            "import sys\n"
+            f"os.environ['LEARNLOG_PROJECT_ROOT'] = {str(project_root)!r}\n"
+            "import learnlog\n"
+            "print(learnlog.repo.workdir)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(subdir), env=test_env,
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == str(project_root)
+        assert (project_root / ".learnlog").is_dir()
+        assert not (subdir / ".learnlog").exists()
+
+    @pytest.mark.parametrize(
+        ("argv", "expected_script", "expected_args"),
+        [
+            ([""], "<repl>", "(none)"),
+            (["-c", "print(1)"], "<python -c>", "print(1)"),
+            (["-m", "pip", "--version"], "<python -m>",
+             "pip --version"),
+            (["/tmp/demo.py", "arg1"], "demo.py", "arg1"),
+            (["/tmp/.venv/bin/pytest", "-q"], "pytest", "-q"),
+        ],
+    )
+    def test_normalises_main_invocation(
+        self, workdir, test_env, argv, expected_script, expected_args,
+    ):
+        script = workdir / "test_main_invocation.py"
         script.write_text(
             "import sys\n"
-            "sys.argv = ['learnlog', 'play']\n"
+            f"sys.argv = {argv!r}\n"
             "import learnlog\n"
-            "assert learnlog.repo is None\n"
         )
         result = subprocess.run(
             [sys.executable, str(script)],
@@ -513,6 +695,40 @@ class TestInitialize:
             capture_output=True, text=True, timeout=30,
         )
         assert result.returncode == 0
+        git_result = subprocess.run(
+            ["git", "--git-dir=.learnlog",
+             "--work-tree=.", "log", "-1", "--format=%B"],
+            cwd=str(workdir),
+            capture_output=True, text=True,
+        )
+        msg = git_result.stdout
+        assert f"Script: {expected_script}" in msg
+        assert f"Arguments: {expected_args}" in msg
+
+    def test_input_calls_are_logged_once_for_piped_stdin(
+        self, workdir, test_env,
+    ):
+        script = workdir / "test_input_once.py"
+        script.write_text(
+            "import learnlog\n"
+            "value = input()\n"
+            "print(value)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(workdir), env=test_env,
+            input="hello\n",
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0
+        git_result = subprocess.run(
+            ["git", "--git-dir=.learnlog",
+             "--work-tree=.", "log", "-1", "--format=%B"],
+            cwd=str(workdir),
+            capture_output=True, text=True,
+        )
+        msg = git_result.stdout
+        assert msg.count("stdin: hello\n") == 1
 
     def test_uses_existing_repo_from_subdirectory(
         self, workdir, test_env
@@ -551,6 +767,92 @@ class TestInitialize:
             capture_output=True, text=True,
         )
         assert "hello.py" in git_result.stdout
+@
+
+Let's verify the helper pieces directly.
+The [[input()]] wrapper must add a line only when stdin is not already
+an [[InputCapture]], and the REPL helpers must format and install
+inline capture correctly.
+
+<<test functions>>=
+def test_wrap_input_logs_when_stdin_is_not_wrapped(monkeypatch):
+    import learnlog
+
+    log = learnlog.IOLog()
+    monkeypatch.setattr(learnlog.sys, "stdin", io.StringIO())
+    wrapped = learnlog._wrap_input(lambda prompt="": "typed", log)
+
+    assert wrapped() == "typed"
+    assert "stdin: typed\n" in log.getvalue()
+
+
+def test_wrap_input_skips_duplicate_log_when_stdin_is_wrapped():
+    import learnlog
+
+    log = learnlog.IOLog()
+    wrapped_stdin = learnlog.InputCapture(io.StringIO("typed\n"), log)
+    original_stdin = learnlog.sys.stdin
+    learnlog.sys.stdin = wrapped_stdin
+    try:
+        wrapped = learnlog._wrap_input(lambda prompt="": "typed", log)
+        assert wrapped() == "typed"
+    finally:
+        learnlog.sys.stdin = original_stdin
+
+    assert log.getvalue() == ""
+
+
+def test_log_repl_statement_formats_multiline_input():
+    import learnlog
+
+    log = learnlog.IOLog()
+    learnlog._log_repl_statement(
+        log,
+        "for i in range(2):\n    print(i)",
+    )
+
+    assert log.getvalue() == (
+        "stdin: >>> for i in range(2):\n"
+        "stdin: ...     print(i)\n"
+    )
+
+
+def test_install_repl_capture_logs_inline_repl_events():
+    import learnlog
+
+    class FakePyreplWrapper:
+        def input(self, prompt=""):
+            return "typed"
+
+    class FakePyreplReadline:
+        _wrapper = FakePyreplWrapper()
+
+    class FakeSimpleInteract:
+        pass
+
+    simple_interact = FakeSimpleInteract()
+    simple_interact.multiline_input = lambda more_lines, ps1, ps2: "2+2"
+
+    log = learnlog.IOLog()
+    restore = learnlog._install_repl_capture(
+        "<repl>",
+        log,
+        pyrepl_readline=FakePyreplReadline,
+        simple_interact=simple_interact,
+    )
+
+    assert restore is not None
+    assert simple_interact.multiline_input(None, ">>> ", "... ") == "2+2"
+    assert FakePyreplReadline._wrapper.input("prompt") == "typed"
+
+    restore()
+    assert simple_interact.multiline_input(None, ">>> ", "... ") == "2+2"
+    assert FakePyreplReadline._wrapper.input("prompt") == "typed"
+
+    assert log.getvalue() == (
+        "stdin: >>> 2+2\n"
+        "stdin: typed\n"
+    )
 @
 
 
@@ -632,12 +934,14 @@ def on_exit():
     """
     global repo, iolog, exception_info
     global original_stdout, original_stderr, original_stdin
+    global original_input, repl_capture_restore
 
     if repo is None:
         return
 
     try:
         <<restore original streams>>
+        <<restore REPL capture>>
         <<finalise the run>>
     except Exception:
         pass
@@ -650,6 +954,13 @@ if original_stderr is not None:
     sys.stderr = original_stderr
 if original_stdin is not None:
     sys.stdin = original_stdin
+if original_input is not None:
+    builtins.input = original_input
+@
+
+<<restore REPL capture>>=
+if repl_capture_restore is not None:
+    repl_capture_restore()
 @
 
 <<finalise the run>>=
@@ -801,4 +1112,873 @@ explicit setup needed.
 
 <<auto-initialize on import>>=
 initialize()
+@
+
+
+\section{Auto-starting without explicit import}
+\label{autostart}
+
+The mechanism described so far captures everything \emph{after} the
+interpreter reaches \mintinline{python}{import learnlog}.
+Everything \emph{before} that line is invisible to us---and for
+beginners, the commonest failure mode lives there.
+A [[SyntaxError]] in [[main.py]] (a stray colon, a missing paren,
+indentation that mixes tabs and spaces) aborts the interpreter
+during \emph{compilation} of the script, before a single top-level
+statement runs.
+No hooks, no capture, nothing in the log.
+Yet chasing syntax errors is a central debugging activity for
+first-year students; omitting those runs leaves a visible gap in
+both teaching and research data.
+
+We need to attach \emph{before} CPython compiles the main script,
+without changing how students launch their programs: [[python
+main.py]], the VS Code \textbf{Run} button, and \texttt{F5} must
+all keep working.
+Python's [[site.py]] evaluates any line beginning with [[import]]
+inside a [[.pth]] file at interpreter startup---ahead of the main
+script and therefore ahead of parse errors in it.
+So [[learnlog init]] installs a one-line
+[[learnlog-autostart.pth]] into the venv's [[site-packages]]:
+\begin{minted}{python}
+import learnlog._autostart; learnlog._autostart.autostart()
+\end{minted}
+
+The [[_autostart]] module is a \emph{gate}: it decides whether
+\emph{this} interpreter invocation should be logged and, if so,
+its explicit [[autostart()]] entry point imports [[learnlog]], reusing the ordinary
+\mintinline{python}{import learnlog} machinery
+(\cref{autostart on import}).
+Rather than duplicate the repository-discovery path, the gate
+communicates the project root to [[initialize]] by setting
+[[LEARNLOG_PROJECT_ROOT]] in the environment.
+
+\paragraph{Why \texttt{.pth} rather than \texttt{sitecustomize.py}.}
+The venv may already carry a [[sitecustomize.py]] written by
+another tool (Python loads only one).
+Multiple [[.pth]] files coexist, so we cannot collide.
+The same trick powers [[coverage.py]]'s subprocess auto-start
+([[coverage.pth]])---so the mechanism is proven at scale.
+
+\paragraph{Scope.}
+After [[learnlog init]] the venv is the unit of logging: every
+invocation of the venv's interpreter is captured.
+Scripts anywhere on disk (including [[/tmp]]), the REPL,
+[[python -c]], [[python -m foo]], [[pip]], [[pytest]], editor
+linters that shell out to this interpreter, and every [[learnlog]]
+subcommand \emph{except} [[learnlog init]] itself---all logged.
+Students who want to work untracked step outside the venv.
+
+\paragraph{What slips through.}
+Python launched with [[-S]] (skips [[site.py]] and therefore
+[[.pth]] files), embedded interpreters, other virtualenvs,
+and any invocation with [[LEARNLOG_SKIP_AUTOSTART=1]] in the
+environment.
+The opt-out variable is a deliberate escape hatch used by
+learnlog's own test suite: without it, running [[pytest]] inside
+the development venv would recursively log every test run.
+
+
+\subsection{Shape of the module}
+
+The module is a small script with one explicit startup entry point.
+The imports are ordinary; the body is a gate helper plus an
+[[autostart()]] function that the [[.pth]] line calls.
+The whole thing lives inside a bare [[try]]/[[except Exception:
+pass]]: [[.pth]] files execute on \emph{every} Python startup,
+including tools that have nothing to do with learnlog, so a
+traceback here would break unrelated programs.
+
+<<[[_autostart.py]]>>=
+"""Autostart hook installed by ``learnlog init``.
+
+A ``.pth`` file in the venv's ``site-packages`` imports this
+module and calls ``autostart()``, which decides whether
+``learnlog`` should activate for the current interpreter invocation
+and, if so, imports the package to trigger its own initialisation
+path.
+
+Test-friendly: each helper accepts optional overrides so unit tests
+can exercise the gate without monkeypatching ``sys`` or the
+filesystem wholesale.
+"""
+import os
+import sys
+import pathlib
+
+<<autostart marker location>>
+<<autostart gate helpers>>
+<<autostart entry point>>
+
+<<autostart module-level activation>>
+@
+
+
+\subsection{Locating the project root}
+
+The gate must answer a single question for every venv invocation:
+\emph{which [[.learnlog/]] repository should we anchor to?}
+Two sources are available, each with a different failure mode,
+and we combine them.
+
+The \textbf{primary source} is a marker file
+[[learnlog_project_root.txt]] written alongside the [[.pth]] file
+at [[learnlog init]] time.
+It is authoritative because a human ran [[learnlog init]] in the
+project root, so the path it holds is \emph{intentional}.
+But it goes stale: delete or move the project and the marker
+still points at the old location.
+
+The \textbf{backup source} is [[Path(sys.prefix).parent]].
+With the conventional [[<project>/.venv/]] layout (produced by
+both [[learnlog init]] and VS Code's ``Create Environment''),
+this resolves to the project root even after the project is
+renamed or moved---because the venv moves with it.
+But the layout is a convention, not a guarantee: a venv at
+[[~/.venvs/foo]] sits nowhere near the project.
+
+We prefer the marker because it is intentional, and only fall
+through to the backup when the marker is missing or stale.
+When we do fall through, we \emph{rewrite} the marker with the
+backup's path so the next invocation takes the fast path.
+This is the self-healing step: a moved project re-anchors itself
+after one run with no user intervention.
+
+If marker and backup both resolve but point at \emph{different}
+valid project roots (\eg a shared [[~/.venvs/]] directory that
+happens to contain its own [[.learnlog/]]), we stick with the
+marker.
+It was set deliberately; the backup's match is coincidental and
+the marker's project is what the student actually worked on.
+
+The marker path is fixed once the module is installed: the
+[[.pth]] file and the marker are both written into
+[[site-packages]] by [[learnlog init]], and the
+[[_autostart.py]] module lives one level down inside the
+[[learnlog]] package.
+
+<<autostart marker location>>=
+_DEFAULT_MARKER_PATH = (
+    pathlib.Path(__file__).parent.parent
+    / "learnlog_project_root.txt"
+)
+@
+
+Reading the marker is best-effort: the file may be absent
+(first-ever run before init ran), unreadable (permission), or
+stale (points at a path that no longer has a [[.learnlog/]]).
+All three cases collapse to the same answer, [[None]], so the
+caller can try the backup.
+A path with no [[.learnlog/]] subdirectory is treated as stale
+rather than valid-but-empty; this is how we detect moved or
+deleted projects.
+
+<<autostart gate helpers>>=
+def _read_marker(marker_path):
+    """Return the path stored in ``marker_path`` if still valid.
+
+    ``Valid'' means the file exists, is readable, and points at a
+    directory that still contains a ``.learnlog/`` subdirectory.
+    Returns ``None`` otherwise.
+    """
+    try:
+        if not marker_path.exists():
+            return None
+        candidate = pathlib.Path(marker_path.read_text().strip())
+        if (candidate / ".learnlog").is_dir():
+            return candidate
+    except Exception:
+        pass
+    return None
+@
+
+The backup check is simpler: does the venv's parent contain a
+[[.learnlog/]]?
+[[sys.prefix]] is always the venv root when running inside a
+venv, so [[sys.prefix.parent]] is the directory that holds the
+venv.
+
+<<autostart gate helpers>>=
+def _compute_backup_root(sys_prefix):
+    """Return ``sys_prefix``'s parent if it holds ``.learnlog/``.
+
+    Covers the common ``<project>/.venv/`` layout and survives
+    project moves.  Returns ``None`` when the layout does not
+    match.
+    """
+    try:
+        candidate = pathlib.Path(sys_prefix).parent
+        if (candidate / ".learnlog").is_dir():
+            return candidate
+    except Exception:
+        pass
+    return None
+@
+
+Self-healing writes the backup's path back into the marker.
+We swallow write failures silently: on a read-only site-packages
+(unusual but possible), logging still works via the backup path
+every invocation---the self-heal is a performance optimisation,
+not a correctness requirement.
+
+<<autostart gate helpers>>=
+def _self_heal_marker(marker_path, project_root):
+    """Rewrite ``marker_path`` with ``project_root``'s path.
+
+    Best-effort: a read-only ``site-packages`` simply means every
+    invocation falls through to the backup check, which still
+    produces correct logging.
+    """
+    try:
+        marker_path.write_text(
+            str(project_root.resolve()) + "\n"
+        )
+    except Exception:
+        pass
+@
+
+Combining the three pieces: try the marker; on success, stop.
+On failure, try the backup; on success, self-heal and return it.
+If both fail, the interpreter is not running inside a learnlog
+project and we skip activation.
+
+<<autostart gate helpers>>=
+def _resolve_project_root(marker_path=None, sys_prefix=None):
+    """Find the project root, preferring marker over backup.
+
+    On a successful fallback to the backup, rewrites the marker so
+    subsequent invocations take the fast path.  Returns ``None``
+    when neither source is valid.
+    """
+    if marker_path is None:
+        marker_path = _DEFAULT_MARKER_PATH
+    if sys_prefix is None:
+        sys_prefix = sys.prefix
+
+    marker_root = _read_marker(marker_path)
+    if marker_root is not None:
+        return marker_root
+
+    backup_root = _compute_backup_root(sys_prefix)
+    if backup_root is not None:
+        _self_heal_marker(marker_path, backup_root)
+        return backup_root
+
+    return None
+@
+
+
+\subsection{Excluding the bootstrap invocation}
+
+[[learnlog init]] is the one command that must \emph{not} be
+logged: it is creating the repository, so it has no repository
+to commit into yet (or, on re-init, it is changing the repository
+from under itself).
+Every \emph{other} [[learnlog]] subcommand---[[play]], [[export]],
+[[tag]], [[list]], [[analyse]]---is research-valuable data about
+how the student interacts with their own log and must be captured
+like any other program.
+
+We detect [[learnlog init]] by matching [[argv[0]]] against the
+script name and [[argv[1]]] against the literal [[init]].
+[[argv[0]]] can be either the [[learnlog]] entry-point script
+itself (installed in [[<venv>/bin/]]) or a path to the package's
+[[\_\_main\_\_.py]] when invoked as [[python -m learnlog]];
+both contain [[learnlog]] as a path component.
+
+<<autostart gate helpers>>=
+def _is_learnlog_init(argv):
+    """True iff ``argv`` looks like a ``learnlog init`` invocation.
+
+    Recognises the installed ``learnlog`` entry-point script and
+    ``python -m learnlog`` (in which case ``argv[0]`` contains
+    ``learnlog`` as a path component).
+    """
+    if len(argv) < 2 or argv[1] != "init":
+        return False
+    basename = os.path.basename(argv[0])
+    if basename == "learnlog":
+        return True
+    return "learnlog" in pathlib.PurePath(argv[0]).parts
+@
+
+
+\subsection{The activation gate}
+
+The gate combines three skip conditions: the explicit opt-out
+environment variable, the [[learnlog init]] self-exclusion, and
+the absence of any resolvable project root.
+Order does not matter for correctness, only for cost: we check
+the env var first because it is the cheapest, and the root
+resolution last because it may touch the filesystem.
+
+All four parameters default to their real-world values but accept
+overrides; this is what lets the unit tests exercise the gate
+without installing a venv per test.
+
+<<autostart entry point>>=
+def _should_activate(
+    marker_path=None, sys_prefix=None, argv=None, env=None,
+):
+    """Return the project root if learnlog should activate.
+
+    Parameters default to ``sys`` / ``os.environ`` values; tests
+    override them.  Returns ``None`` when the current invocation
+    must be skipped.
+    """
+    if env is None:
+        env = os.environ
+    if argv is None:
+        argv = sys.argv
+    if env.get("LEARNLOG_SKIP_AUTOSTART"):
+        return None
+    if _is_learnlog_init(argv):
+        return None
+    return _resolve_project_root(marker_path, sys_prefix)
+@
+
+
+\subsection{Startup entry point}
+\label{autostart on import}
+
+The last piece runs at interpreter startup---once, when the
+[[.pth]] line calls [[autostart()]].
+Keeping it as an explicit function instead of unconditional
+module-level side effect matters for tests and helper imports:
+unit tests must be able to import [[learnlog._autostart]] to reach
+[[_should_activate]] without mutating the parent process
+environment.
+
+If the gate returns a project root, we stash it in
+[[LEARNLOG_PROJECT_ROOT]] so [[initialize]] will find the right
+[[.learnlog/]] (see task~\#4), then [[import learnlog]] to
+trigger the ordinary import-time initialisation path.
+If the gate returns [[None]], we silently do nothing and the
+interpreter continues as if we were not installed.
+
+The outer [[try]]/[[except]] is non-negotiable.
+A [[.pth]] module runs before user code on every Python
+invocation in the venv---including [[python -m pip install
+something-unrelated]].
+A traceback from this module would spam [[stderr]] and, worse,
+could be confused with an error from the user's command.
+We swallow everything and let the interpreter proceed.
+
+<<autostart module-level activation>>=
+def autostart():
+    """Activate learnlog for this interpreter startup if eligible."""
+    try:
+        _root = _should_activate()
+        if _root is not None:
+            os.environ["LEARNLOG_PROJECT_ROOT"] = str(_root)
+            import learnlog  # noqa: F401 -- triggers initialize()
+    except Exception:
+        pass
+@
+
+
+\subsection{Tests for the gate}
+
+The gate is pure logic over four inputs (marker file, sys.prefix,
+argv, env) and one side effect (marker rewrite on self-heal).
+The fixtures below build a minimal filesystem fixture and then
+drive [[_should_activate]] with explicit overrides---no subprocess,
+no real venv, no patching of [[sys]].
+End-to-end verification that the [[.pth]] hook is actually picked
+up by CPython lives in task~\#6's integration tests.
+
+Importing the module itself must stay side-effect free.
+The actual startup action now lives in [[autostart()]], because test
+modules import [[_should_activate]] directly.
+Without this separation, merely importing the helper module would leak
+[[LEARNLOG_PROJECT_ROOT]] into the parent pytest process and redirect
+later subprocesses into the wrong project.
+
+<<autostart test functions>>=
+def test_importing_autostart_module_has_no_side_effects(monkeypatch):
+    monkeypatch.delenv("LEARNLOG_PROJECT_ROOT", raising=False)
+    import importlib
+    import learnlog._autostart as autostart
+
+    importlib.reload(autostart)
+
+    assert "LEARNLOG_PROJECT_ROOT" not in os.environ
+@
+
+<<test [[_autostart.py]]>>=
+"""Unit tests for the learnlog._autostart gate."""
+import os
+import pathlib
+import pytest
+import select
+import subprocess
+import sys
+
+from learnlog._autostart import _should_activate
+
+<<autostart test helpers>>
+<<autostart test functions>>
+@
+
+A valid project has a [[.learnlog/]] directory; a valid marker
+holds the path to such a project; a ``no-backup'' [[sys.prefix]]
+points somewhere far from any [[.learnlog/]], so tests of the
+marker path are not secretly passing via the backup.
+
+<<autostart test helpers>>=
+@pytest.fixture
+def project(tmp_path):
+    """A directory that looks like a learnlog project."""
+    p = tmp_path / "project"
+    (p / ".learnlog").mkdir(parents=True)
+    return p
+
+
+@pytest.fixture
+def marker(tmp_path, project):
+    """A marker file pointing at ``project``."""
+    m = tmp_path / "marker.txt"
+    m.write_text(str(project) + "\n")
+    return m
+
+
+@pytest.fixture
+def no_backup_prefix(tmp_path):
+    """A ``sys.prefix`` whose parent holds no ``.learnlog/``.
+
+    Isolates marker-based tests from accidentally activating via
+    the backup anchor.
+    """
+    p = tmp_path / "unrelated" / ".venv"
+    p.mkdir(parents=True)
+    return str(p)
+@
+
+The six happy-path invocation shapes exercise the argv parser: a
+normal script, a bare REPL ([[argv[0]]] is the empty string),
+[[python -c]], [[python -m foo]], [[pip]], and [[pytest]].
+Non-init [[learnlog]] subcommands ([[play]], [[export]]) belong
+in the same group: they are research-valuable data and must
+activate.
+One parametrised test covers all eight cases because the gate's
+only argv-dependent decision is the [[learnlog init]] exclusion.
+
+<<autostart test functions>>=
+class TestShouldActivate:
+    @pytest.mark.parametrize("argv", [
+        ["script.py"],
+        [""],
+        ["-c", "1+1"],
+        ["-m", "foo"],
+        ["/venv/bin/pip", "install", "foo"],
+        ["/venv/bin/pytest", "--version"],
+        ["learnlog", "play"],
+        ["learnlog", "export"],
+    ])
+    def test_activates_for_ordinary_invocations(
+        self, project, marker, no_backup_prefix, argv,
+    ):
+        result = _should_activate(
+            marker_path=marker,
+            sys_prefix=no_backup_prefix,
+            argv=argv,
+            env={},
+        )
+        assert result == project
+@
+
+The opt-out env var short-circuits the gate before any filesystem
+probe; a valid marker and backup should both be ignored.
+
+<<autostart test functions>>=
+    def test_skip_env_var_disables_activation(
+        self, marker, no_backup_prefix,
+    ):
+        result = _should_activate(
+            marker_path=marker,
+            sys_prefix=no_backup_prefix,
+            argv=["script.py"],
+            env={"LEARNLOG_SKIP_AUTOSTART": "1"},
+        )
+        assert result is None
+@
+
+Neither marker nor backup resolves means the interpreter is not
+inside a learnlog project; the gate must silently return
+[[None]] rather than raising or synthesising a root.
+
+<<autostart test functions>>=
+    def test_no_anchor_returns_none(
+        self, tmp_path, no_backup_prefix,
+    ):
+        missing_marker = tmp_path / "nonexistent.txt"
+        result = _should_activate(
+            marker_path=missing_marker,
+            sys_prefix=no_backup_prefix,
+            argv=["script.py"],
+            env={},
+        )
+        assert result is None
+@
+
+The [[learnlog init]] self-exclusion must trigger both for the
+installed entry-point script (basename [[learnlog]]) and for
+[[python -m learnlog init]] (argv[0] is a path to
+[[__main__.py]] under a [[learnlog]] directory).
+We split them into two tests because the detection logic has
+two independent branches.
+
+<<autostart test functions>>=
+    def test_learnlog_init_is_skipped(
+        self, marker, no_backup_prefix,
+    ):
+        result = _should_activate(
+            marker_path=marker,
+            sys_prefix=no_backup_prefix,
+            argv=["/venv/bin/learnlog", "init"],
+            env={},
+        )
+        assert result is None
+
+    def test_python_m_learnlog_init_is_skipped(
+        self, marker, no_backup_prefix,
+    ):
+        argv = [
+            "/venv/lib/python3.10/site-packages"
+            "/learnlog/__main__.py",
+            "init",
+        ]
+        result = _should_activate(
+            marker_path=marker,
+            sys_prefix=no_backup_prefix,
+            argv=argv,
+            env={},
+        )
+        assert result is None
+@
+
+When the marker is absent, the backup anchor takes over.
+The self-heal side effect should write the backup's project root
+into the marker file so the next invocation short-circuits to
+the marker.
+
+<<autostart test functions>>=
+    def test_backup_anchor_activates_and_self_heals(
+        self, tmp_path, project,
+    ):
+        missing_marker = tmp_path / "missing.txt"
+        venv = project / ".venv"
+        venv.mkdir()
+        result = _should_activate(
+            marker_path=missing_marker,
+            sys_prefix=str(venv),
+            argv=["script.py"],
+            env={},
+        )
+        assert result == project
+        assert missing_marker.exists()
+        written = pathlib.Path(
+            missing_marker.read_text().strip()
+        )
+        assert written == project.resolve()
+@
+
+A stale marker (points at a deleted project) should be treated
+the same as a missing one: fall through to the backup, and
+rewrite so the project re-anchors itself.
+
+<<autostart test functions>>=
+    def test_stale_marker_falls_through_and_heals(
+        self, tmp_path, project,
+    ):
+        marker = tmp_path / "marker.txt"
+        deleted = tmp_path / "gone"
+        marker.write_text(str(deleted) + "\n")
+        venv = project / ".venv"
+        venv.mkdir()
+        result = _should_activate(
+            marker_path=marker,
+            sys_prefix=str(venv),
+            argv=["script.py"],
+            env={},
+        )
+        assert result == project
+        written = pathlib.Path(marker.read_text().strip())
+        assert written == project.resolve()
+@
+
+If both the marker and the backup resolve but disagree, the
+marker wins deterministically.
+We construct the disagreement by giving the marker and the
+backup different valid projects; the marker's project is what
+[[_should_activate]] must return.
+
+<<autostart test functions>>=
+    def test_marker_wins_when_both_valid_but_differ(
+        self, tmp_path, project,
+    ):
+        alt = tmp_path / "alt_project"
+        (alt / ".learnlog").mkdir(parents=True)
+        marker = tmp_path / "marker.txt"
+        marker.write_text(str(project) + "\n")
+        venv = alt / ".venv"
+        venv.mkdir()
+        result = _should_activate(
+            marker_path=marker,
+            sys_prefix=str(venv),
+            argv=["script.py"],
+            env={},
+        )
+        assert result == project
+@
+
+
+\subsection{End-to-end autostart tests}
+
+The gate tests above prove the decision logic in isolation.
+They do not prove that CPython actually executes the [[.pth]] hook
+early enough, nor that the TTY-only paths work in a real child
+interpreter.
+For that we build a scratch project, wire a scratch venv for
+autostart, and drive the venv's own [[python]] in subprocesses.
+
+We keep these helpers in the autostart section because they verify the
+same feature from the outside.
+The CLI pipeline that writes the marker and hook already has its own
+tests near [[write_autostart_files]] in [[cli.nw]].
+Repeating [[learnlog init]] here would also force these tests to fetch
+[[learnlog]] from [[pip]].
+Instead we write the same two autostart files into a temporary venv and
+add one extra [[.pth]] file that points at this checkout's [[src/]]
+tree.
+Naming that extra file [[000-learnlog-source.pth]] makes [[site.py]]
+add the source tree before it reaches [[learnlog-autostart.pth]], so the
+autostart import resolves to the code under test.
+
+<<autostart test helpers>>=
+def _repo_root():
+    """Return the repository root for this checkout."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def _autostart_env():
+    """Return an environment that permits autostarted commits."""
+    env = os.environ.copy()
+    env.pop("LEARNLOG_SKIP_AUTOSTART", None)
+    env.pop("LEARNLOG_PROJECT_ROOT", None)
+    env["GIT_AUTHOR_NAME"] = "Test"
+    env["GIT_AUTHOR_EMAIL"] = "test@test"
+    env["GIT_COMMITTER_NAME"] = "Test"
+    env["GIT_COMMITTER_EMAIL"] = "test@test"
+    return env
+
+
+def _prepare_autostart_project(tmp_path):
+    """Create a project root and a venv wired for autostart."""
+    from learnlog import cli
+    from learnlog.gitrepo import LearnlogRepo
+
+    project = tmp_path / "project"
+    project.mkdir()
+    LearnlogRepo(project)
+
+    venv_dir = project / ".venv"
+    subprocess.run(
+        [sys.executable, "-m", "virtualenv", str(venv_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    purelib = cli.venv_purelib(venv_dir)
+    source_pth = purelib / "000-learnlog-source.pth"
+    source_pth.write_text(str((_repo_root() / "src").resolve()) + "\n")
+    cli.write_autostart_files(venv_dir, project)
+
+    return project, venv_dir
+
+
+def _venv_binary(venv_dir, name):
+    """Return ``name`` from ``venv_dir`` using the real helper."""
+    from learnlog import cli
+
+    return cli.find_in_venv(venv_dir, name)
+
+
+def _git_history(project):
+    """Return the full commit bodies in the learnlog repo."""
+    result = subprocess.run(
+        ["git", "--git-dir=.learnlog", "--work-tree=.",
+         "log", "--format=%B"],
+        cwd=str(project),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    return result.stdout
+
+
+def _run_in_pty(command, *, cwd, env, input_text):
+    """Run ``command`` with a TTY-backed stdin/stdout/stderr."""
+    import pty
+
+    master_fd, slave_fd = pty.openpty()
+    output = bytearray()
+    try:
+        proc = subprocess.Popen(
+            command,
+            cwd=str(cwd),
+            env=env,
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+        )
+    finally:
+        os.close(slave_fd)
+
+    try:
+        os.write(master_fd, input_text.encode())
+        while True:
+            chunk = b""
+            ready, _, _ = select.select([master_fd], [], [], 0.1)
+            if ready:
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError:
+                    chunk = b""
+                if chunk:
+                    output.extend(chunk)
+            if proc.poll() is not None and not chunk:
+                break
+    finally:
+        os.close(master_fd)
+
+    return proc.wait(timeout=30), output.decode(errors="replace")
+@
+
+The first integration test proves the central motivation for autostart:
+the hook runs before the main script is compiled, so a top-level
+[[SyntaxError]] is still recorded in the learnlog history.
+
+<<autostart test functions>>=
+def test_autostart_captures_syntax_error_end_to_end(tmp_path):
+    project, venv_dir = _prepare_autostart_project(tmp_path)
+    main = project / "main.py"
+    main.write_text("def f(:\n    pass\n")
+
+    result = subprocess.run(
+        [str(_venv_binary(venv_dir, "python")), str(main)],
+        cwd=str(project),
+        env=_autostart_env(),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode != 0
+    assert "SyntaxError" in result.stderr
+
+    history = _git_history(project)
+    assert "Script: main.py" in history
+    assert "SyntaxError" in history
+@
+
+The second test covers the widened invocation scope through the real
+[[.pth]] hook: [[python -c]], a non-project script, the [[pip]] entry
+point, and a TTY-backed [[input()]] call.
+These are the places where explicit [[import learnlog]] never helped,
+yet autostart is supposed to make them all visible in the same
+repository.
+
+<<autostart test functions>>=
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="TTY integration uses pty"
+)
+def test_autostart_captures_common_invocations(tmp_path):
+    project, venv_dir = _prepare_autostart_project(tmp_path)
+    env = _autostart_env()
+    python = _venv_binary(venv_dir, "python")
+    pip = _venv_binary(venv_dir, "pip")
+    quick = tmp_path / "quick.py"
+    ask = tmp_path / "ask.py"
+
+    quick.write_text("print('quick')\n")
+    ask.write_text("value = input()\nprint(value)\n")
+
+    subprocess.run(
+        [str(python), "-c", "print(1)"],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    subprocess.run(
+        [str(pip), "--version"],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    subprocess.run(
+        [str(python), str(quick)],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+
+    returncode, _ = _run_in_pty(
+        [str(python), str(ask)],
+        cwd=project,
+        env=env,
+        input_text="hello from tty\n",
+    )
+
+    assert returncode == 0
+
+    history = _git_history(project)
+    assert "Script: <python -c>" in history
+    assert "Script: pip" in history
+    assert "Script: quick.py" in history
+    assert "stdin: hello from tty\n" in history
+@
+
+The REPL path is the remaining truly interactive case.
+CPython reads top-level statements through [[readline]] on the TTY,
+not through [[sys.stdin]], so the only way to verify our history-diff
+approach is to drive a real REPL over a pseudoterminal.
+
+<<autostart test functions>>=
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="pty is unavailable on Windows"
+)
+def test_autostart_captures_repl_history_and_traceback(tmp_path):
+    project, venv_dir = _prepare_autostart_project(tmp_path)
+    returncode, _ = _run_in_pty(
+        [str(_venv_binary(venv_dir, "python"))],
+        cwd=project,
+        env=_autostart_env(),
+        input_text=(
+            "2+2\n"
+            "raise RuntimeError('x')\n"
+            "exit()\n"
+        ),
+    )
+
+    assert returncode == 0
+
+    history = _git_history(project)
+    assert "Script: <repl>" in history
+    assert "stdin: >>> 2+2\n" in history
+    assert "stdin: >>> raise RuntimeError('x')\n" in history
+    assert "stdin: >>> exit()\n" in history
+    assert "RuntimeError" in history
 @

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -586,6 +586,7 @@ class TestFindLearnlogDir:
 
 
 \section{Initialisation}
+\label{sec:initialize}
 
 The [[initialize]] function is called at import time.
 It detects the main script, creates (or opens) the learnlog repository,
@@ -1978,7 +1979,7 @@ unit tests must be able to import [[learnlog._autostart]] to reach
 environment.
 
 If the gate returns a project root, we stash it in
-[[LEARNLOG_PROJECT_ROOT]] so [[initialize]] (\cref{learnlog})
+[[LEARNLOG_PROJECT_ROOT]] so [[initialize]] (\cref{sec:initialize})
 will find the right [[.learnlog/]], then [[import learnlog]] to
 trigger the ordinary import-time initialisation path.
 If the gate returns [[None]], we silently do nothing and the

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -136,21 +136,34 @@ to see the available tags and check out the lecture they want to review.
 Alternatively, when a shared Git remote is not available, the
 teacher can export the log as a portable bundle file:
 \begin{minted}{bash}
-learnlog export -o lecture01.learnlog
+learnlog export -o prgi26.learnlog
 \end{minted}
 The teacher distributes the file (\eg via a course page) and
 students replay it directly:
 \begin{minted}{bash}
-learnlog play -f lecture01.learnlog
+learnlog play -f prgi26.learnlog
 \end{minted}
-When the teacher wants to publish the second lecture, they don't want to 
-include the first lecture again.
-They can export only the new commits since the last tag:
+At the start of each lecture the teacher runs
+\mintinline{bash}{learnlog tag lectureNN}, and at the end of the
+lecture they re-export and re-upload [[prgi26.learnlog]].
+The bundle always contains the full history, so a student who
+downloads the latest file sees every lecture to date.
+Students list what is available in the bundle and play the
+lecture they want:
 \begin{minted}{bash}
-learnlog export -o lecture02.learnlog lecture02
+learnlog list -f prgi26.learnlog
+learnlog play -f prgi26.learnlog
 \end{minted}
-This only works if they ran \mintinline{bash}{learnlog tag lecture02} at the 
-start of the second lecture, as described above.
+The [[list]] output shows each run's timestamp and command so a
+student can locate the most recent lecture's runs without
+separate release notes from the teacher.
+
+We deliberately export the whole log each time rather than just
+the new commits: Git bundles for a rev-range declare the earlier
+commits as prerequisites, and [[learnlog play -f]] unpacks by
+cloning, which cannot satisfy prerequisites.
+Re-exporting the full log keeps the consumption path as simple as
+\enquote{download the latest file, play it}.
 
 \subsection{Studying how students code}
 
@@ -181,11 +194,11 @@ tags [[lab1]] and [[lab2]] are included.
 Alternatively, the student can export the log as a bundle and
 submit it through the course platform:
 \begin{minted}{bash}
-learnlog export -o alice-log.bundle
+learnlog export -o alice-log.learnlog
 \end{minted}
 The researcher then replays it directly:
 \begin{minted}{bash}
-learnlog play -f alice-log.bundle
+learnlog play -f alice-log.learnlog
 \end{minted}
 This gives a complete timeline of how students develop and debug
 their code---useful for research purposes or to help students
@@ -394,10 +407,10 @@ learnlog push
 If you submit via Canvas or email:
 
 ```bash
-learnlog export -o mylog.bundle
+learnlog export -o mylog.learnlog
 ```
 
-Upload `mylog.bundle` through the course platform as instructed.
+Upload `mylog.learnlog` through the course platform as instructed.
 
 ## Troubleshooting
 

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -78,6 +78,160 @@ This gives a complete timeline of how students develop and debug
 their code---useful for research purposes or to help students
 refine their debugging techniques.
 
+\paragraph{A student-facing onboarding page.}
+Both use cases above assume students have already installed the
+package, configured a virtual environment, and added
+\mintinline{python}{import learnlog} to their programs.
+For first-year students this is not routine, so teachers need
+onboarding material.
+Rather than leave each teacher to write their own, we ship a
+ready-to-publish Canvas page, [[students.md]], tangled from this
+chapter.
+Tangling ties the instructions to the documented behaviour: when a
+command or default changes here, the student page changes with it,
+eliminating the drift that plagues separately maintained onboarding
+documents.
+
+The page carries YAML frontmatter understood by the [[canvaslms]]
+command-line tool, so the teacher publishes it with a single
+command:
+\begin{minted}{bash}
+canvaslms pages edit --create -c COURSE \
+  -f src/learnlog/students.md
+\end{minted}
+We deliberately omit course-specific metadata---Canvas module
+assignment and stable-identification regex---because one tangled
+file must work unchanged across every course using learnlog.
+Teachers add those fields via the Canvas UI after publishing, or
+through a per-course deployment wrapper.
+
+<<[[students.md]]>>=
+---
+title: Using learnlog in VS Code
+url: using-learnlog-in-vs-code
+published: true
+front_page: false
+editing_roles: teachers
+---
+
+# Using learnlog in VS Code
+
+`learnlog` records your Python development — code changes, inputs,
+outputs, and errors — into a hidden Git repository. You can review
+your own work later, and when asked, share it with your teacher.
+
+This page walks through setup, use, and submission in VS Code.
+
+## What you need
+
+- **Python 3.10 or newer.** Check with `python3 --version` in a
+  terminal.
+- **Visual Studio Code** with the **Python** extension (by
+  Microsoft).
+- **Git** on your `PATH` (`git --version`).
+- A project folder for your course work, opened in VS Code.
+
+## One-time setup
+
+Open the integrated terminal in VS Code (menu **View → Terminal**)
+and run these commands from your project folder.
+
+### 1. Create and activate a virtual environment
+
+```bash
+python3 -m venv .venv
+# Linux / macOS:
+source .venv/bin/activate
+# Windows (PowerShell):
+.venv\Scripts\Activate.ps1
+```
+
+Make sure VS Code uses this interpreter: open the Command Palette
+(**Ctrl+Shift+P** or **Cmd+Shift+P**), run **Python: Select
+Interpreter**, and pick the one under `.venv`.
+
+### 2. Install learnlog
+
+```bash
+pip install learnlog
+```
+
+### 3. Initialise the log repository
+
+```bash
+learnlog init
+```
+
+This creates a hidden `.learnlog/` directory at the top of your
+project. The active virtual environment is remembered, so scripts
+you run later use the correct interpreter automatically.
+
+## Everyday use
+
+Add a single line as the **first line** of each Python file you
+want logged:
+
+```python
+import learnlog
+```
+
+Run the script however you normally do — the VS Code **Run**
+button, `python myscript.py` in the terminal, or **F5** for the
+debugger. Every run is recorded: source code, command-line
+arguments, stdin/stdout/stderr, and any exception traceback.
+
+`learnlog` never changes what your program prints or does. If
+logging fails for any reason, your program keeps running.
+
+## Review your own session
+
+To replay your recent runs interactively:
+
+```bash
+learnlog play
+```
+
+Use the arrow keys to step through events and **q** to quit.
+
+## Submit or share your log
+
+Your teacher will usually pick **one** of these two options. Use
+the one they ask for.
+
+### Option A: push to a shared Git remote
+
+If your teacher has given you a remote URL:
+
+```bash
+learnlog set-remote <remote-url>
+learnlog push
+```
+
+### Option B: export a bundle file
+
+If you submit via Canvas or email:
+
+```bash
+learnlog export -o mylog.bundle
+```
+
+Upload `mylog.bundle` through the course platform as instructed.
+
+## Troubleshooting
+
+- **`learnlog: command not found`** — the virtual environment
+  isn't active. Re-run the activation command for your platform,
+  or reopen VS Code's terminal after selecting the interpreter.
+- **Nothing appears in `.learnlog/` after running a script** —
+  make sure `import learnlog` is the first non-comment line of the
+  script you're actually running.
+- **You already had a project Git repository** — the `.learnlog/`
+  directory is independent; do **not** `git add .learnlog/` in
+  your project's own repository. It manages itself.
+- **Need to start over** — delete `.learnlog/` and run
+  `learnlog init` again; your own code is untouched.
+@
+
 The design is guided by two constraints:
 \begin{description}
 \item[Transparency] The student's program must behave identically

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -232,6 +232,8 @@ Upload `mylog.bundle` through the course platform as instructed.
   `learnlog init` again; your own code is untouched.
 @
 
+\section{Code overview}
+
 The design is guided by two constraints:
 \begin{description}
 \item[Transparency] The student's program must behave identically
@@ -243,8 +245,6 @@ The design is guided by two constraints:
   program executes and amending it with results afterwards.
 \end{description}
 
-
-\section{Code overview}
 
 <<[[__init__.py]]>>=
 """Automatic logging of student code development.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,15 +5,19 @@
 # discovers those chunks and tangles them to tests/unit/test_*.py files.
 
 # Auto-discover test chunks in .nw files
+# A single .nw file may define several "<<test [[X.py]]>>" chunks, one per
+# module it tests; emit one target per distinct chunk.
 # Output format: "unit/test_modulename.py:sourcefile.nw:test%20[[modulename.py]]"
 define find_tests
 ( \
 	find ../src -name '*.nw' | xargs grep -l '<<test \[\[.*\.py\]\]>>' | \
 		while read file; do \
-			chunk=$$(grep -o '<<test \[\[\([^]]*\)\.py\]\]>>' "$$file" | head -1 | \
-			         sed 's/<<test \[\[\(.*\)\.py\]\]>>/\1/'); \
-			chunk_safe=$$(echo "$$chunk" | sed 's/ /%20/g'); \
-			echo "unit/test_$${chunk_safe}.py:$$file:test%20[[$$chunk_safe.py]]"; \
+			grep -o '<<test \[\[\([^]]*\)\.py\]\]>>' "$$file" | sort -u | \
+			sed 's/<<test \[\[\(.*\)\.py\]\]>>/\1/' | \
+			while read chunk; do \
+				chunk_safe=$$(echo "$$chunk" | sed 's/ /%20/g'); \
+				echo "unit/test_$${chunk_safe}.py:$$file:test%20[[$$chunk_safe.py]]"; \
+			done; \
 		done; \
 ) | sort -u
 endef


### PR DESCRIPTION
- **Add Canvas-ready student onboarding page**
- **Slightly improves intro**
- **Add venv autostart capture**
- **Fix autostart bootstrap exclusions**
- **Cover REPL input capture end to end**
- **Add readline fallback for REPL capture**
- **Rewrite onboarding page around autostart**
- **Reframe overview around pipx and autostart**
- **Drop orphan cref to removed PEP 668 subsection**
- **Updates learnlog intro/overview chapter**
- **Add shell activate/deactivate commands**
- **Standardize bundle extension to .learnlog and drop rev-range**
- **Address literate and LaTeX review feedback**
- **Complete CLI subcommand list in CLAUDE.md**
- **Tighten cref target from chapter to initialisation section**
