### PR TITLE
nw review fixes

### DIFF
--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -238,6 +238,10 @@ def resolve_source(source=None):
 
 To unbundle, we create a temporary directory and use
 [[git clone]] with the bundle as the remote.
+A temporary directory is required because cloning directly into the
+caller's working tree would write a [[remote.origin.url]] pointing at
+the bundle path into [[.learnlog/config]], leaving the user with a
+remote they did not configure.
 We point [[GIT_DIR]] at the cloned repo's [[.git/]] so that
 [[LearnlogRepo.git()]] can query it.
 However, [[LearnlogRepo]] expects the git directory to be named

--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -1280,7 +1280,7 @@ driven by explicit test inputs, stub [[virtualenv.cli_run]]
 so no real venv is created, stub [[subprocess.run]] so no
 network traffic happens, stub [[write_autostart_files]] so
 the autostart concern is tested separately, and always
-[[delenv VIRTUAL\_ENV]] before each scenario so that the
+[[delenv VIRTUAL_ENV]] before each scenario so that the
 test runner's own venv (pytest typically runs inside one)
 does not accidentally select the \enquote{active venv}
 branch.

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -1874,7 +1874,7 @@ both teaching and research data.
 
 We need to attach \emph{before} CPython compiles the main script,
 without changing how students launch their programs: [[python
-main.py]], the VS Code \textbf{Run} button, and \texttt{F5} must
+main.py]], the VS Code \textbf{Run} button, and [[F5]] must
 all keep working.
 Python's [[site.py]] evaluates any line beginning with [[import]]
 inside a [[.pth]] file at interpreter startup---ahead of the main

--- a/src/learnlog/progsnap2.nw
+++ b/src/learnlog/progsnap2.nw
@@ -455,10 +455,10 @@ output chunk.
 
 Each chunk is a tuple of [[(event_type, text)]]:
 \begin{description}
-\item[[[X-Run.Output]]] contains the joined output
+\item[ [[X-Run.Output]] ] contains the joined output
   lines (with [[stderr]] merged into output, since
   ProgSnap2 does not distinguish them).
-\item[[[X-Run.Input]]] contains the text of a single
+\item[ [[X-Run.Input]] ] contains the text of a single
   [[stdin]] line.
 \end{description}
 
@@ -1463,14 +1463,14 @@ tools that follow the ProgSnap2 specification.
 
 The reader returns a dict with four keys:
 \begin{description}
-\item[[[metadata]]] The [[DatasetMetadata.csv]] key--value
+\item[ [[metadata]] ] The [[DatasetMetadata.csv]] key--value
   pairs as a dict.
-\item[[[events]]] The [[MainTable.csv]] rows as a list of
+\item[ [[events]] ] The [[MainTable.csv]] rows as a list of
   dicts, preserving the CSV column names as keys.
-\item[[[code_states]]] A nested dict mapping each
+\item[ [[code_states]] ] A nested dict mapping each
   [[CodeStateID]] to a dict of
   \{filename: file content\} pairs.
-\item[[[resources]]] A dict mapping resource paths
+\item[ [[resources]] ] A dict mapping resource paths
   (e.g.\ [[Resources/io_3.txt]]) to their text content.
 \end{description}
 

--- a/src/learnlog/tutorials/analysing-progsnap2.nw
+++ b/src/learnlog/tutorials/analysing-progsnap2.nw
@@ -66,8 +66,10 @@ required_patterns:
 hint: Quote the boundary so the shell keeps it as one argument.
 ```
 
-Use a start boundary such as `X-Tag=lab1` to keep only the events from
-the first matching tag onward.
+Pass a start boundary so the report keeps only the events from the
+first matching tag onward, for example:
+
+`learnlog analyse 'X-Tag=lab1' -f course.progsnap2 -o report.tex`
 
 # Filter a tagged range
 

--- a/src/learnlog/tutorials/export-and-share.nw
+++ b/src/learnlog/tutorials/export-and-share.nw
@@ -53,8 +53,10 @@ required_patterns:
 hint: Point `origin` at a Git repository URL or local bare repo path.
 ```
 
-Choose a remote repository and configure it with `learnlog set-remote`.
-For local practice, a path such as `../course-log.git` works well.
+Choose a remote repository and configure it with
+`learnlog set-remote ../course.git`.
+For local practice, a bare repository path such as `../course.git`
+works well; for sharing across machines, pass a real URL instead.
 
 # Push the log to the remote
 

--- a/src/learnlog/viewer.nw
+++ b/src/learnlog/viewer.nw
@@ -27,6 +27,8 @@ navigation and ``play_batch`` for non-interactive output.
 
 <<viewer imports>>
 
+<<viewer constants>>
+
 <<viewer classes>>
 <<viewer functions>>
 @
@@ -54,6 +56,23 @@ from __future__ import annotations
 import sys
 
 from learnlog.commits import get_commit_detail
+@
+
+
+\section{Layout constants}
+
+The header occupies row~0 and the footer the last row, leaving the
+content area in between.  We name those offsets so the draw chunks
+read as layout statements rather than arithmetic.
+[[SHORT_HASH_LEN]] follows Git's own default for short hash
+abbreviation, which lets readers recognise hashes at a glance
+without losing uniqueness on lab-sized repositories.
+
+<<viewer constants>>=
+SHORT_HASH_LEN = 7
+HEADER_ROW = 0
+CONTENT_START_ROW = 1
+FOOTER_OFFSET_FROM_BOTTOM = 2
 @
 
 
@@ -178,15 +197,15 @@ We truncate to the terminal width to avoid curses errors.
 <<draw header>>=
 header = (
     f"[{self.index + 1}/{len(self.commits)}] "
-    f"{commit['hash'][:7]} "
+    f"{commit['hash'][:SHORT_HASH_LEN]} "
     f"\u2014 {commit['subject']}"
 )
 header = header[:width - 1]
 try:
     import curses
-    stdscr.addstr(0, 0, header, curses.A_REVERSE)
+    stdscr.addstr(HEADER_ROW, 0, header, curses.A_REVERSE)
     stdscr.addstr(
-        0, len(header),
+        HEADER_ROW, len(header),
         " " * (width - len(header) - 1),
         curses.A_REVERSE,
     )
@@ -208,8 +227,8 @@ the area between the header (row~0) and the footer
 (last row).
 
 <<draw content area>>=
-content_start = 1
-content_end = height - 2
+content_start = CONTENT_START_ROW
+content_end = height - FOOTER_OFFSET_FROM_BOTTOM
 visible = content_end - content_start
 
 self.scroll = max(


### PR DESCRIPTION
- **Fix LaTeX-safe notation in .nw sources**
- **Explain temp-dir use in cli.nw unbundle path**
- **Extract viewer layout constants**
- **Improve example invariance in two tutorials**
