### PR TITLE
Accept alternative valid tutorial solutions

### DIFF
--- a/src/learnlog/cli.nw
+++ b/src/learnlog/cli.nw
@@ -1579,13 +1579,25 @@ shell step after the explicit activation lesson installs
 That keeps the tutorial honest about fresh shells while still making the
 project environment available for any extra commands the student tries
 before returning from the step.
-The run step therefore only needs to require [[python hello.py]] and the
-expected [[Hello, world!]] output.
-The final playback step still looks for [[Script: hello.py]], the
-recorded output, and the diff in [[learnlog play -b]], so the tutorial
-only passes after a real learnlog-managed run.
-We lock those constraints in with regression tests against the generated
-tutorial resource.
+The run step requires a [[python hello.py]] invocation and a greeting on
+stdout.
+We express both with [[pytorial]] regex matches rather than plain
+[[contains]] strings so that equally valid solutions are not rejected:
+the command tolerates [[python3]] and a leading [[./]], and the greeting
+tolerates case and punctuation variation around [[hello]] and [[world]].
+The final playback step looks for [[learnlog play -b]] (accepting the
+long [[--batch]] alternative through a regex), then verifies the
+recorded run by matching [[hello.py]] and the same lenient greeting,
+plus the stable [[diff --git]] header that proves a real diff was
+rendered.
+We deliberately drop the [[Script: hello.py]] and
+[[stdout: Hello, world!]] line prefixes from the validation: those
+strings are an internal output format of [[learnlog play -b]], not
+anything the student types, and pinning the tutorial to that exact
+format would make it fragile to future viewer changes without
+strengthening the learning signal.
+We lock the resulting mixed-mode pattern list in with regression tests
+against the generated tutorial resource.
 
 <<test functions>>=
 def test_tutorial_list_lists_builtin_tutorials():
@@ -1656,14 +1668,11 @@ def test_getting_started_reactivates_and_checks_playback():
     assert run_step.edit_file is None
     assert run_step.pre_command == 'eval "$(learnlog activate)"\n'
     assert tuple(
-        pattern.pattern for pattern in run_step.required_patterns
-    ) == (
-        "python hello.py",
-        "Hello, world!",
-    )
-    assert all(
-        pattern.mode == "contains"
+        (pattern.pattern, pattern.mode)
         for pattern in run_step.required_patterns
+    ) == (
+        (r"python3?\s+(?:\./)?hello\.py", "regex"),
+        (r"(?i)hello[,!\s]*world", "regex"),
     )
     assert run_step.check_command is None
     assert "fresh shell" in run_step.instructions
@@ -1672,16 +1681,13 @@ def test_getting_started_reactivates_and_checks_playback():
     assert play_step.title == "Inspect the recorded run"
     assert play_step.pre_command == 'eval "$(learnlog activate)"\n'
     assert tuple(
-        pattern.pattern for pattern in play_step.required_patterns
-    ) == (
-        "learnlog play -b",
-        "Script: hello.py",
-        "stdout: Hello, world!",
-        "diff --git",
-    )
-    assert all(
-        pattern.mode == "contains"
+        (pattern.pattern, pattern.mode)
         for pattern in play_step.required_patterns
+    ) == (
+        (r"learnlog\s+play\b[^\n]*(?:-b\b|--batch\b)", "regex"),
+        ("hello.py", "contains"),
+        (r"(?i)hello[,!\s]*world", "regex"),
+        ("diff --git", "contains"),
     )
     assert play_step.check_command is None
     assert "Script: hello.py" in play_step.instructions

--- a/src/learnlog/tutorials/analysing-progsnap2.nw
+++ b/src/learnlog/tutorials/analysing-progsnap2.nw
@@ -37,9 +37,12 @@ project with `learnlog export --progsnap2`.
 
 ```tutorial-step
 required_patterns:
-  - learnlog analyse
-  - -f
-  - -o
+  - mode: regex
+    pattern: 'learnlog\s+analyse\b'
+  - mode: regex
+    pattern: '(?<!\S)(?:-f|--from)\b\s+\S+'
+  - mode: regex
+    pattern: '(?<!\S)(?:-o|--output)\b\s+\S+'
 hint: A typical command is `learnlog analyse -f course.progsnap2 -o report.tex`.
 ```
 
@@ -62,7 +65,8 @@ that can be compiled directly, rather than a fragment for inclusion.
 
 ```tutorial-step
 required_patterns:
-  - X-Tag=lab1
+  - mode: regex
+    pattern: 'X-Tag=\S+'
 hint: Quote the boundary so the shell keeps it as one argument.
 ```
 
@@ -75,8 +79,8 @@ first matching tag onward, for example:
 
 ```tutorial-step
 required_patterns:
-  - X-Tag=lab1
-  - X-Tag=lab2
+  - mode: regex
+    pattern: 'X-Tag=\S+[^\n]*X-Tag=\S+'
 hint: Pass two `Column=Regex` boundaries to restrict the analysis window.
 ```
 

--- a/src/learnlog/tutorials/export-and-share.nw
+++ b/src/learnlog/tutorials/export-and-share.nw
@@ -27,7 +27,8 @@ summary: Export bundles, make ProgSnap2 data, and sync through a remote.
 
 ```tutorial-step
 required_patterns:
-  - learnlog export -o course.learnlog
+  - mode: regex
+    pattern: 'learnlog\s+export\b[^\n]*(?<!\S)(?:-o|--output)\b\s+\S+\.learnlog\b'
 hint: Pick an output name ending in `.learnlog`.
 ```
 
@@ -38,7 +39,10 @@ This is the easiest format to hand to someone for playback.
 
 ```tutorial-step
 required_patterns:
-  - learnlog export --progsnap2 -o course.progsnap2
+  - mode: regex
+    pattern: 'learnlog\s+export\b[^\n]*--progsnap2\b'
+  - mode: regex
+    pattern: 'learnlog\s+export\b[^\n]*(?<!\S)(?:-o|--output)\b\s+\S+\.progsnap2\b'
 hint: Use `--progsnap2` when the goal is analysis rather than playback.
 ```
 
@@ -49,7 +53,8 @@ education analysis workflows.
 
 ```tutorial-step
 required_patterns:
-  - learnlog set-remote
+  - mode: regex
+    pattern: 'learnlog\s+set-remote\s+\S+'
 hint: Point `origin` at a Git repository URL or local bare repo path.
 ```
 
@@ -72,7 +77,8 @@ Run `learnlog push` to send the whole recorded history to `origin`.
 
 ```tutorial-step
 required_patterns:
-  - learnlog clone
+  - mode: regex
+    pattern: 'learnlog\s+clone\s+\S+'
 hint: Try cloning into a second directory to simulate another machine.
 ```
 

--- a/src/learnlog/tutorials/getting-started.nw
+++ b/src/learnlog/tutorials/getting-started.nw
@@ -76,8 +76,10 @@ Save `print("Hello, world!")` before returning.
 pre_command: |
   eval "$(learnlog activate)"
 required_patterns:
-  - python hello.py
-  - Hello, world!
+  - mode: regex
+    pattern: 'python3?\s+(?:\./)?hello\.py'
+  - mode: regex
+    pattern: '(?i)hello[,!\s]*world'
 hint: The tutorial already re-activated the project environment; run `python hello.py`.
 ```
 
@@ -93,9 +95,11 @@ run automatically.
 pre_command: |
   eval "$(learnlog activate)"
 required_patterns:
-  - learnlog play -b
-  - "Script: hello.py"
-  - "stdout: Hello, world!"
+  - mode: regex
+    pattern: 'learnlog\s+play\b[^\n]*(?:-b\b|--batch\b)'
+  - hello.py
+  - mode: regex
+    pattern: '(?i)hello[,!\s]*world'
   - diff --git
 hint: The tutorial already re-activated the project environment; use `learnlog play -b` and confirm the recorded `hello.py` run appears.
 ```

--- a/src/learnlog/tutorials/playback-and-tagging.nw
+++ b/src/learnlog/tutorials/playback-and-tagging.nw
@@ -26,7 +26,8 @@ summary: Review a log in batch and interactive mode, then jump to tags.
 
 ```tutorial-step
 required_patterns:
-  - learnlog play -b
+  - mode: regex
+    pattern: 'learnlog\s+play\b[^\n]*(?:-b\b|--batch\b)'
 hint: Start with `learnlog play -b` so you can read the whole log.
 ```
 
@@ -38,7 +39,8 @@ output.
 
 ```tutorial-step
 required_patterns:
-  - learnlog tag lab1
+  - mode: regex
+    pattern: 'learnlog\s+tag\s+(?!-)\S+'
 hint: Tag the current commit with a short name such as `lab1`.
 ```
 
@@ -49,7 +51,8 @@ example with `learnlog tag lab1`.
 
 ```tutorial-step
 required_patterns:
-  - learnlog tag -l
+  - mode: regex
+    pattern: 'learnlog\s+tag\b[^\n]*(?:-l\b|--list\b)'
 hint: Run `learnlog tag -l` to list the tags in the `.learnlog/` repository.
 ```
 
@@ -59,7 +62,8 @@ List the tags so you can confirm that your new marker exists.
 
 ```tutorial-step
 required_patterns:
-  - learnlog play -b lab1
+  - mode: regex
+    pattern: 'learnlog\s+play\b(?:[^\n]*(?:-b\b|--batch\b)[^\n]*\s+(?!-)\S+|\s+(?!-)\S+[^\n]*(?:-b\b|--batch\b))'
 hint: Pass the tag name after `learnlog play -b`.
 ```
 
@@ -70,7 +74,8 @@ instead of from the beginning of the history.
 
 ```tutorial-step
 required_patterns:
-  - learnlog play lab1
+  - mode: regex
+    pattern: 'learnlog\s+play\s+(?!-)\S+'
 hint: Launch the interactive viewer and quit with `q` when you are done.
 ```
 


### PR DESCRIPTION
Switch tutorial validation patterns to pytorial's regex mode where
substring matching was rejecting equally valid student solutions:

- Accept long-form flags interchangeably with short forms
  (--batch/-b, --output/-o, --from/-f, --list/-l)
- Accept any student-chosen tag name (was hardcoded to lab1/lab2)
- Accept any output filename (was hardcoded to course.learnlog and
  course.progsnap2)
- Tolerate arbitrary whitespace between command tokens
- Relax greeting output to (?i)hello[,!\s]*world and drop the
  brittle Script:/stdout: line-prefix labels from getting-started

Also tighten patterns that previously passed without a required
argument: learnlog set-remote and learnlog clone now require a URL,
and learnlog play <tag> no longer matches a flag-only invocation.

Update cli.nw test assertions to compare (pattern, mode) pairs
against the new mixed contains/regex pattern list, and rewrite the
surrounding prose to explain why each mode was chosen.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
