### PR TITLE
Add quick start and VSCodium to student onboarding page

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "dbosk-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dbosk/claude-skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dbosk-skills@dbosk-skills": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,18 @@ Tutorials follow the same rule: the sources live in
 - `noweave` extracts LaTeX documentation
 - Code chunks: `<<[[filename.py]]>>=`
 - Test chunks: `<<test [[filename.py]]>>=` (auto-discovered by `tests/Makefile`)
-- **Always activate the `literate-programming` skill before editing `.nw` files**
-- Use the `review-literate-programming` skill to review literate quality of changes
+- **Always activate the `dbosk-skills:literate-programming` skill before editing `.nw` files**
+- Use the `dbosk-skills:review` skill to review literate quality of changes
+
+These skills come from the `dbosk-skills` plugin (github.com/dbosk/claude-skills),
+declared in `.claude/settings.json` so they install automatically, including in
+remote (web) sessions.
 
 ### Related skills
 
-- `latex-writing` — for LaTeX conventions in `.nw` documentation sections
-- `variation-theory` — for structuring educational content in documentation
-- `try-first-tell-later` — for pedagogical exercise design
+- `dbosk-skills:latex-writing` — for LaTeX conventions in `.nw` documentation sections
+- `dbosk-skills:variation-theory` — for structuring educational content in documentation
+- `dbosk-skills:try-first-tell-later` — for pedagogical exercise design
 
 ## Architecture
 

--- a/src/learnlog/learnlog.nw
+++ b/src/learnlog/learnlog.nw
@@ -258,6 +258,17 @@ command or default changes here, the student page changes with it,
 eliminating the drift that plagues separately maintained onboarding
 documents.
 
+The page leads with a three-step quick start---install
+[[learnlog]], create a directory for the course, run
+\mintinline{bash}{learnlog init python} there---so a student is
+recording within minutes without reading the whole page.
+The detailed sections that follow remain as reference and
+troubleshooting for the students who need them.
+The page also addresses VSCodium alongside VS~Code: the
+open-source build behaves identically for our purposes, the only
+difference being that its extensions come from the Open~VSX
+registry rather than the Microsoft marketplace.
+
 The page carries YAML frontmatter understood by the [[canvaslms]]
 command-line tool, so the teacher publishes it with a single
 command:
@@ -283,27 +294,55 @@ through a per-course deployment wrapper.
 
 <<[[students.md]]>>=
 ---
-title: Using learnlog in VS Code
+title: Using learnlog in VS Code or VSCodium
 url: using-learnlog-in-vs-code
 published: true
 front_page: false
 editing_roles: teachers
 ---
 
-# Using learnlog in VS Code
+# Using learnlog in VS Code or VSCodium
 
 `learnlog` records your Python development — code changes, inputs,
 outputs, and errors — into a hidden Git repository. You can review
 your own work later, and when asked, share it with your teacher.
 
 This page walks through setup, use, and submission in VS Code.
+Everything works the same in VSCodium, the open-source build of
+VS Code — wherever this page says VS Code, both apply.
+
+## Quick start
+
+1. **Install learnlog.** In a terminal (**View → Terminal** in
+   VS Code), install
+   [pipx](https://pipx.pypa.io/stable/installation/) if you do
+   not already have it, then run:
+
+   ```bash
+   pipx install learnlog
+   ```
+
+2. **Create a directory for the course** and open it in VS Code
+   (**File → Open Folder**). Keep all your work for the course
+   inside it.
+
+3. **Turn on recording.** In the integrated terminal, run:
+
+   ```bash
+   learnlog init python
+   ```
+
+That's it — work as you normally would, and every run of your
+code is recorded. The rest of this page explains each step in
+more detail, how to review and share your log, and what to do if
+something does not work.
 
 ## What you need
 
 - **Python 3.10 or newer.** Check with `python3 --version` in a
   terminal.
-- **Visual Studio Code** with the **Python** extension (by
-  Microsoft).
+- **Visual Studio Code** or **VSCodium** with the **Python**
+  extension (in VSCodium, install it from the Open VSX registry).
 - **Git** on your `PATH` (`git --version`).
 
 ## One-time setup


### PR DESCRIPTION
Adds a simple, student-facing instruction for using learnlog with VS Code or VSCodium, as a **Quick start** section at the top of the existing `students.md` Canvas page (tangled from `src/learnlog/learnlog.nw`):

1. Install learnlog — install [pipx](https://pipx.pypa.io/stable/installation/) if needed, then `pipx install learnlog` (one-liner + link; the per-platform matrix stays in the detailed section below).
2. Create a directory for the course and open it in VS Code (**File → Open Folder**).
3. Run `learnlog init python` in the integrated terminal.

Also:

- Page title is now *"Using learnlog in VS Code or VSCodium"*; the Canvas `url:` is unchanged so existing links keep working.
- VSCodium is covered explicitly (works identically; Python extension comes from Open VSX).
- The woven chapter documents the design decision (quick-start-first, detailed sections as reference).

Only `src/learnlog/learnlog.nw` is touched for this part — `students.md` is an existing tangle target, so no Makefile/catalog/doc changes are needed.

Verified: `make students.md` tangles cleanly with intact frontmatter, and the full test suite passes (283 passed).

## Auto-install the dbosk-skills plugin in Claude Code sessions

A second commit makes the skills referenced by `CLAUDE.md` available in remote (web) Claude Code sessions:

- New `.claude/settings.json` declares the `dbosk/claude-skills` plugin marketplace via `extraKnownMarketplaces` and enables `dbosk-skills@dbosk-skills`, so the plugin installs automatically at session start (including cloud sessions, where github.com is reachable under the default network policy).
- `CLAUDE.md` skill references updated to the namespaced plugin form (`dbosk-skills:literate-programming`, etc.); the previous `review-literate-programming` reference was wrong and now points at `dbosk-skills:review`.

The matching `.claude-plugin/{marketplace,plugin}.json` metadata is already on dbosk/claude-skills `main` (commit 639922c), so the auto-install works as soon as a session starts on this branch. Full verification: start a fresh remote session on this branch and confirm the `dbosk-skills:*` skills appear in the available-skills list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016a4qnGe4WdPk7oWdDaQQhz